### PR TITLE
Walk: handle `switch_range` correctly

### DIFF
--- a/src/Walk.zig
+++ b/src/Walk.zig
@@ -196,7 +196,6 @@ fn expr(w: *Walk, scope: *Scope, node: Ast.Node.Index) Oom!void {
         .switch_case_inline => unreachable, // Handled in `switchExpr`.
         .switch_case_one => unreachable, // Handled in `switchExpr`.
         .switch_case_inline_one => unreachable, // Handled in `switchExpr`.
-        .switch_range => unreachable, // Handled in `switchExpr`.
 
         .asm_output => unreachable, // Handled in `asmExpr`.
         .asm_input => unreachable, // Handled in `asmExpr`.
@@ -256,6 +255,7 @@ fn expr(w: *Walk, scope: *Scope, node: Ast.Node.Index) Oom!void {
         .@"orelse",
         .array_type,
         .array_access,
+        .switch_range,
         => {
             try expr(w, scope, node_datas[node].lhs);
             try expr(w, scope, node_datas[node].rhs);


### PR DESCRIPTION
An example of where the previous `unreachable` could be hit is in the documentation for `std.fmt`.