### PR TITLE
Implement Markdown rendering

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -8,6 +8,7 @@ const log = std.log;
 const assert = std.debug.assert;
 const Ast = std.zig.Ast;
 const Walk = @import("Walk.zig");
+const markdown = @import("markdown.zig");
 
 const js = struct {
     extern "js" fn log(ptr: [*]const u8, len: usize) void;
@@ -227,14 +228,12 @@ fn decl_fields_fallible(decl_index: Decl.Index) ![]Ast.Node.Index {
 
 export fn decl_field_html(decl_index: Decl.Index, field_node: Ast.Node.Index) String {
     string_result.clearRetainingCapacity();
-    decl_field_html_fallible(&string_result, &markdown_input, decl_index, field_node) catch
-        @panic("OOM");
+    decl_field_html_fallible(&string_result, decl_index, field_node) catch @panic("OOM");
     return String.init(string_result.items);
 }
 
 fn decl_field_html_fallible(
     out: *std.ArrayListUnmanaged(u8),
-    buffer: *std.ArrayListUnmanaged(u8),
     decl_index: Decl.Index,
     field_node: Ast.Node.Index,
 ) !void {
@@ -247,10 +246,9 @@ fn decl_field_html_fallible(
     const field = ast.fullContainerField(field_node).?;
     const first_doc_comment = findFirstDocComment(ast, field.firstToken());
 
-    collect_docs(buffer, ast, first_doc_comment) catch @panic("OOM");
-    if (buffer.items.len > 0) {
+    if (ast.tokens.items(.tag)[first_doc_comment] == .doc_comment) {
         try out.appendSlice(gpa, "<div class=\"fieldDocs\">");
-        render_markdown(out, buffer.items) catch @panic("OOM");
+        try render_docs(out, ast, first_doc_comment, false);
         try out.appendSlice(gpa, "</div>");
     }
 }
@@ -362,15 +360,8 @@ export fn decl_name(decl_index: Decl.Index) String {
 export fn decl_docs_html(decl_index: Decl.Index, short: bool) String {
     const decl = decl_index.get();
     const ast = decl.file.ast();
-    collect_docs(&markdown_input, ast, decl.extra_info().first_doc_comment) catch @panic("OOM");
-    const chomped = c: {
-        const s = markdown_input.items;
-        if (!short) break :c s;
-        const nl = std.mem.indexOfScalar(u8, s, '\n') orelse s.len;
-        break :c s[0..nl];
-    };
     string_result.clearRetainingCapacity();
-    render_markdown(&string_result, chomped) catch @panic("OOM");
+    render_docs(&string_result, ast, decl.extra_info().first_doc_comment, short) catch @panic("OOM");
     return String.init(string_result.items);
 }
 
@@ -391,6 +382,69 @@ fn collect_docs(
         },
         else => break,
     };
+}
+
+fn render_docs(
+    out: *std.ArrayListUnmanaged(u8),
+    ast: *const Ast,
+    first_doc_comment: Ast.TokenIndex,
+    short: bool,
+) Oom!void {
+    const token_tags = ast.tokens.items(.tag);
+
+    var parser = try markdown.Parser.init(gpa);
+    defer parser.deinit();
+    var it = first_doc_comment;
+    while (true) : (it += 1) switch (token_tags[it]) {
+        .doc_comment, .container_doc_comment => {
+            const line = ast.tokenSlice(it)[3..];
+            if (short and line.len == 0) break;
+            try parser.feedLine(line);
+        },
+        else => break,
+    };
+
+    var parsed_doc = try parser.endInput();
+    defer parsed_doc.deinit(gpa);
+
+    const Writer = std.ArrayListUnmanaged(u8).Writer;
+    const Renderer = markdown.Renderer(Writer, void);
+    const renderer: Renderer = .{
+        .context = {},
+        .renderFn = struct {
+            fn render(
+                r: Renderer,
+                doc: markdown.Document,
+                node: markdown.Document.Node.Index,
+                writer: Writer,
+            ) !void {
+                const data = doc.nodes.items(.data)[@intFromEnum(node)];
+                switch (doc.nodes.items(.tag)[@intFromEnum(node)]) {
+                    // TODO: detect identifier references (dotted paths) in
+                    // these three node types and render them appropriately.
+                    // Also, syntax highlighting can be applied in code blocks
+                    // unless the tag says otherwise.
+                    .code_block => {
+                        const tag = doc.string(data.code_block.tag);
+                        _ = tag;
+                        const content = doc.string(data.code_block.content);
+                        try writer.print("<pre><code>{}</code></pre>\n", .{markdown.fmtHtml(content)});
+                    },
+                    .code_span => {
+                        const content = doc.string(data.text.content);
+                        try writer.print("<code>{}</code>", .{markdown.fmtHtml(content)});
+                    },
+                    .text => {
+                        const content = doc.string(data.text.content);
+                        try writer.print("{}", .{markdown.fmtHtml(content)});
+                    },
+
+                    else => try Renderer.renderDefault(r, doc, node, writer),
+                }
+            }
+        }.render,
+    };
+    try renderer.render(parsed_doc, out.writer(gpa));
 }
 
 export fn decl_type_html(decl_index: Decl.Index) String {
@@ -1227,8 +1281,6 @@ export fn find_package_root(pkg: PackageIndex) Decl.Index {
 
 /// Set by `set_input_string`.
 var input_string: std.ArrayListUnmanaged(u8) = .{};
-/// Only for direct use by exported functions.
-var markdown_input: std.ArrayListUnmanaged(u8) = .{};
 
 export fn set_input_string(len: usize) [*]u8 {
     input_string.resize(gpa, len) catch @panic("OOM");
@@ -1303,18 +1355,6 @@ export fn namespace_members(parent: Decl.Index, include_private: bool) Slice(Dec
     }
 
     return Slice(Decl.Index).init(g.members.items);
-}
-
-/// Appends to `out`, does not clear it.
-fn render_markdown(out: *std.ArrayListUnmanaged(u8), input: []const u8) !void {
-    if (input.len == 0) return;
-    // TODO implement a custom markdown renderer
-    // resist urge to use a third party implementation
-    // this implementation will have zig specific tweaks such as inserting links
-    // syntax highlighting, recognizing identifiers even outside of backticks, etc.
-    try out.appendSlice(gpa, "<p>");
-    try appendEscaped(out, input);
-    try out.appendSlice(gpa, "</p>");
 }
 
 fn appendEscaped(out: *std.ArrayListUnmanaged(u8), s: []const u8) !void {

--- a/src/markdown.zig
+++ b/src/markdown.zig
@@ -1,0 +1,933 @@
+//! Markdown parsing and rendering support.
+//!
+//! A Markdown document consists of a series of blocks. Depending on its type,
+//! each block may contain other blocks, inline content, or nothing. The
+//! supported blocks are as follows:
+//!
+//! - **List** - a sequence of list items of the same type.
+//!
+//! - **List item** - unordered list items start with `-`, `*`, or `+` followed
+//!   by a space. Ordered list items start with a number between 0 and
+//!   999,999,999, followed by a `.` or `)` and a space. The number of an
+//!   ordered list item only matters for the first item in the list (to
+//!   determine the starting number of the list). All subsequent ordered list
+//!   items will have sequentially increasing numbers.
+//!
+//!   All list items may contain block content. Any content indented at least as
+//!   far as the end of the list item marker (including the space after it) is
+//!   considered part of the list item.
+//!
+//!   Lists which have no blank lines between items or between direct children
+//!   of items are considered _tight_, and direct child paragraphs of tight list
+//!   items are rendered without `<p>` tags.
+//!
+//! - **Table** - a sequence of adjacent table row lines, where each line starts
+//!   and ends with a `|`, and cells within the row are delimited by `|`s.
+//!
+//!   The first or second row of a table may be a _header delimiter row_, which
+//!   is a row consisting of cells of the pattern `---` (for unset column
+//!   alignment), `:--` (for left alignment), `:-:` (for center alignment), or
+//!   `--:` (for right alignment). The number of `-`s must be at least one, but
+//!   is otherwise arbitrary. If there is a row just before the header delimiter
+//!   row, it becomes the header row for the table (a table need not have a
+//!   header row at all).
+//!
+//! - **Heading** - a sequence of between 1 and 6 `#` characters, followed by a
+//!   space and further inline content on the same line.
+//!
+//! - **Code block** - a sequence of at least 3 `` ` `` characters (a _fence_),
+//!   optionally followed by a "tag" on the same line, and continuing until a
+//!   line consisting only of a closing fence whose length matches the opening
+//!   fence, or until the end of the containing block.
+//!
+//!   The content of a code block is not parsed as inline content. It is
+//!   included verbatim in the output document (minus leading indentation up to
+//!   the position of the opening fence).
+//!
+//! - **Blockquote** - a sequence of lines preceded by `>` characters.
+//!
+//! - **Paragraph** - ordinary text, parsed as inline content, ending with a
+//!   blank line or the end of the containing block.
+//!
+//!   Paragraphs which are part of another block may be "lazily" continued by
+//!   subsequent paragraph lines even if those lines would not ordinarily be
+//!   considered part of the containing block. For example, this is a single
+//!   list item, not a list item followed by a paragraph:
+//!
+//!   ```markdown
+//!   - First line of content.
+//!   This content is still part of the paragraph,
+//!   even though it isn't indented far enough.
+//!   ```
+//!
+//! - **Thematic break** - a line consisting of at least three matching `-`,
+//!   `_`, or `*` characters and, optionally, spaces.
+//!
+//! Indentation may consist of spaces and tabs. The use of tabs is not
+//! recommended: a tab is treated the same as a single space for the purpose of
+//! determining the indentation level, and is not recognized as a space for
+//! block starters which require one (for example, `-` followed by a tab is not
+//! a valid list item).
+//!
+//! The supported inlines are as follows:
+//!
+//! - **Link** - of the format `[text](target)`. `text` may contain inline
+//!   content. `target` may contain `\`-escaped characters and balanced
+//!   parentheses.
+//!
+//! - **Image** - a link directly preceded by a `!`. The link text is
+//!   interpreted as the alt text of the image.
+//!
+//! - **Emphasis** - a run of `*` or `_` characters may be an emphasis opener,
+//!   closer, or both. For `*` characters, the run may be an opener as long as
+//!   it is not directly followed by a whitespace character (or the end of the
+//!   inline content) and a closer as long as it is not directly preceded by
+//!   one. For `_` characters, this rule is strengthened by requiring that the
+//!   run also be preceded by a whitespace or punctuation character (for
+//!   openers) or followed by one (for closers), to avoid mangling `snake_case`
+//!   words.
+//!
+//!   The rule for emphasis handling is greedy: any run that can close existing
+//!   emphasis will do so, otherwise it will open emphasis. A single run may
+//!   serve both functions: the middle `**` in the following example both closes
+//!   the initial emphasis and opens a new one:
+//!
+//!   ```markdown
+//!   *one**two*
+//!   ```
+//!
+//!   A single `*` or `_` is used for normal emphasis (HTML `<em>`), and a
+//!   double `**` or `__` is used for strong emphasis (HTML `<strong>`). Even
+//!   longer runs may be used to produce further nested emphasis (though only
+//!   `***` and `___` to produce `<em><strong>` is really useful).
+//!
+//! - **Code span** - a run of `` ` `` characters, terminated by a matching run
+//!   or the end of inline content. The content of a code span is not parsed
+//!   further.
+//!
+//! - **Text** - normal text is interpreted as-is, except that `\` may be used
+//!   to escape any punctuation character, preventing it from being interpreted
+//!   according to other syntax rules. A `\` followed by a line break within a
+//!   paragraph is interpreted as a hard line break.
+//!
+//!   Any null bytes or invalid UTF-8 bytes within text are replaced with Unicode
+//!   replacement characters, `U+FFFD`.
+
+const std = @import("std");
+const testing = std.testing;
+
+pub const Document = @import("markdown/Document.zig");
+pub const Parser = @import("markdown/Parser.zig");
+pub const Renderer = @import("markdown/renderer.zig").Renderer;
+pub const renderNodeInlineText = @import("markdown/renderer.zig").renderNodeInlineText;
+pub const fmtHtml = @import("markdown/renderer.zig").fmtHtml;
+
+// Avoid exposing main to other files merely importing this one.
+pub const main = if (@import("root") == @This())
+    mainImpl
+else
+    @compileError("only available as root source file");
+
+fn mainImpl() !void {
+    const gpa = std.heap.c_allocator;
+
+    var parser = try Parser.init(gpa);
+    defer parser.deinit();
+
+    var stdin_buf = std.io.bufferedReader(std.io.getStdIn().reader());
+    var line_buf = std.ArrayList(u8).init(gpa);
+    defer line_buf.deinit();
+    while (stdin_buf.reader().streamUntilDelimiter(line_buf.writer(), '\n', null)) {
+        if (line_buf.getLastOrNull() == '\r') _ = line_buf.pop();
+        try parser.feedLine(line_buf.items);
+        line_buf.clearRetainingCapacity();
+    } else |err| switch (err) {
+        error.EndOfStream => {},
+        else => |e| return e,
+    }
+
+    var doc = try parser.endInput();
+    defer doc.deinit(gpa);
+
+    var stdout_buf = std.io.bufferedWriter(std.io.getStdOut().writer());
+    try doc.render(stdout_buf.writer());
+    try stdout_buf.flush();
+}
+
+test "empty document" {
+    try testRender("", "");
+    try testRender("   ", "");
+    try testRender("\n \n\t\n   \n", "");
+}
+
+test "unordered lists" {
+    try testRender(
+        \\- Spam
+        \\- Spam
+        \\- Spam
+        \\- Eggs
+        \\- Bacon
+        \\- Spam
+        \\
+        \\* Spam
+        \\* Spam
+        \\* Spam
+        \\* Eggs
+        \\* Bacon
+        \\* Spam
+        \\
+        \\+ Spam
+        \\+ Spam
+        \\+ Spam
+        \\+ Eggs
+        \\+ Bacon
+        \\+ Spam
+        \\
+    ,
+        \\<ul>
+        \\<li>Spam</li>
+        \\<li>Spam</li>
+        \\<li>Spam</li>
+        \\<li>Eggs</li>
+        \\<li>Bacon</li>
+        \\<li>Spam</li>
+        \\</ul>
+        \\<ul>
+        \\<li>Spam</li>
+        \\<li>Spam</li>
+        \\<li>Spam</li>
+        \\<li>Eggs</li>
+        \\<li>Bacon</li>
+        \\<li>Spam</li>
+        \\</ul>
+        \\<ul>
+        \\<li>Spam</li>
+        \\<li>Spam</li>
+        \\<li>Spam</li>
+        \\<li>Eggs</li>
+        \\<li>Bacon</li>
+        \\<li>Spam</li>
+        \\</ul>
+        \\
+    );
+}
+
+test "ordered lists" {
+    try testRender(
+        \\1. Breakfast
+        \\2. Second breakfast
+        \\3. Lunch
+        \\2. Afternoon snack
+        \\1. Dinner
+        \\6. Dessert
+        \\7. Midnight snack
+        \\
+        \\1) Breakfast
+        \\2) Second breakfast
+        \\3) Lunch
+        \\2) Afternoon snack
+        \\1) Dinner
+        \\6) Dessert
+        \\7) Midnight snack
+        \\
+        \\1001. Breakfast
+        \\2. Second breakfast
+        \\3. Lunch
+        \\2. Afternoon snack
+        \\1. Dinner
+        \\6. Dessert
+        \\7. Midnight snack
+        \\
+        \\1001) Breakfast
+        \\2) Second breakfast
+        \\3) Lunch
+        \\2) Afternoon snack
+        \\1) Dinner
+        \\6) Dessert
+        \\7) Midnight snack
+        \\
+    ,
+        \\<ol>
+        \\<li>Breakfast</li>
+        \\<li>Second breakfast</li>
+        \\<li>Lunch</li>
+        \\<li>Afternoon snack</li>
+        \\<li>Dinner</li>
+        \\<li>Dessert</li>
+        \\<li>Midnight snack</li>
+        \\</ol>
+        \\<ol>
+        \\<li>Breakfast</li>
+        \\<li>Second breakfast</li>
+        \\<li>Lunch</li>
+        \\<li>Afternoon snack</li>
+        \\<li>Dinner</li>
+        \\<li>Dessert</li>
+        \\<li>Midnight snack</li>
+        \\</ol>
+        \\<ol start="1001">
+        \\<li>Breakfast</li>
+        \\<li>Second breakfast</li>
+        \\<li>Lunch</li>
+        \\<li>Afternoon snack</li>
+        \\<li>Dinner</li>
+        \\<li>Dessert</li>
+        \\<li>Midnight snack</li>
+        \\</ol>
+        \\<ol start="1001">
+        \\<li>Breakfast</li>
+        \\<li>Second breakfast</li>
+        \\<li>Lunch</li>
+        \\<li>Afternoon snack</li>
+        \\<li>Dinner</li>
+        \\<li>Dessert</li>
+        \\<li>Midnight snack</li>
+        \\</ol>
+        \\
+    );
+}
+
+test "nested lists" {
+    try testRender(
+        \\- - Item 1.
+        \\  - Item 2.
+        \\Item 2 continued.
+        \\  * New list.
+        \\
+    ,
+        \\<ul>
+        \\<li><ul>
+        \\<li>Item 1.</li>
+        \\<li>Item 2.
+        \\Item 2 continued.</li>
+        \\</ul>
+        \\<ul>
+        \\<li>New list.</li>
+        \\</ul>
+        \\</li>
+        \\</ul>
+        \\
+    );
+}
+
+test "lists with block content" {
+    try testRender(
+        \\1. Item 1.
+        \\2. Item 2.
+        \\
+        \\   This one has another paragraph.
+        \\3. Item 3.
+        \\
+        \\- > Blockquote.
+        \\- - Sub-list.
+        \\  - Sub-list continued.
+        \\  * Different sub-list.
+        \\- ## Heading.
+        \\
+        \\  Some contents below the heading.
+        \\  1. Item 1.
+        \\  2. Item 2.
+        \\  3. Item 3.
+        \\
+    ,
+        \\<ol>
+        \\<li><p>Item 1.</p>
+        \\</li>
+        \\<li><p>Item 2.</p>
+        \\<p>This one has another paragraph.</p>
+        \\</li>
+        \\<li><p>Item 3.</p>
+        \\</li>
+        \\</ol>
+        \\<ul>
+        \\<li><blockquote>
+        \\<p>Blockquote.</p>
+        \\</blockquote>
+        \\</li>
+        \\<li><ul>
+        \\<li>Sub-list.</li>
+        \\<li>Sub-list continued.</li>
+        \\</ul>
+        \\<ul>
+        \\<li>Different sub-list.</li>
+        \\</ul>
+        \\</li>
+        \\<li><h2>Heading.</h2>
+        \\<p>Some contents below the heading.</p>
+        \\<ol>
+        \\<li>Item 1.</li>
+        \\<li>Item 2.</li>
+        \\<li>Item 3.</li>
+        \\</ol>
+        \\</li>
+        \\</ul>
+        \\
+    );
+}
+
+test "tables" {
+    try testRender(
+        \\| Operator | Meaning          |
+        \\| :------: | ---------------- |
+        \\| `+`      | Add              |
+        \\| `-`      | Subtract         |
+        \\| `*`      | Multiply         |
+        \\| `/`      | Divide           |
+        \\| `??`     | **Not sure yet** |
+        \\
+        \\| Item 1 | Value 1 |
+        \\| Item 2 | Value 2 |
+        \\| Item 3 | Value 3 |
+        \\| Item 4 | Value 4 |
+        \\
+        \\| :--- | :----: | ----: |
+        \\| Left | Center | Right |
+        \\
+    ,
+        \\<table>
+        \\<tr>
+        \\<th style="text-align: center">Operator</th>
+        \\<th>Meaning</th>
+        \\</tr>
+        \\<tr>
+        \\<td style="text-align: center"><code>+</code></td>
+        \\<td>Add</td>
+        \\</tr>
+        \\<tr>
+        \\<td style="text-align: center"><code>-</code></td>
+        \\<td>Subtract</td>
+        \\</tr>
+        \\<tr>
+        \\<td style="text-align: center"><code>*</code></td>
+        \\<td>Multiply</td>
+        \\</tr>
+        \\<tr>
+        \\<td style="text-align: center"><code>/</code></td>
+        \\<td>Divide</td>
+        \\</tr>
+        \\<tr>
+        \\<td style="text-align: center"><code>??</code></td>
+        \\<td><strong>Not sure yet</strong></td>
+        \\</tr>
+        \\</table>
+        \\<table>
+        \\<tr>
+        \\<td>Item 1</td>
+        \\<td>Value 1</td>
+        \\</tr>
+        \\<tr>
+        \\<td>Item 2</td>
+        \\<td>Value 2</td>
+        \\</tr>
+        \\<tr>
+        \\<td>Item 3</td>
+        \\<td>Value 3</td>
+        \\</tr>
+        \\<tr>
+        \\<td>Item 4</td>
+        \\<td>Value 4</td>
+        \\</tr>
+        \\</table>
+        \\<table>
+        \\<tr>
+        \\<td style="text-align: left">Left</td>
+        \\<td style="text-align: center">Center</td>
+        \\<td style="text-align: right">Right</td>
+        \\</tr>
+        \\</table>
+        \\
+    );
+}
+
+test "table with uneven number of columns" {
+    try testRender(
+        \\| One |
+        \\| :-- | :--: |
+        \\| One | Two | Three |
+        \\
+    ,
+        \\<table>
+        \\<tr>
+        \\<th style="text-align: left">One</th>
+        \\</tr>
+        \\<tr>
+        \\<td style="text-align: left">One</td>
+        \\<td style="text-align: center">Two</td>
+        \\<td>Three</td>
+        \\</tr>
+        \\</table>
+        \\
+    );
+}
+
+test "table with escaped pipes" {
+    try testRender(
+        \\| One \| Two |
+        \\| --- | --- |
+        \\| One \| Two |
+        \\
+    ,
+        \\<table>
+        \\<tr>
+        \\<th>One | Two</th>
+        \\</tr>
+        \\<tr>
+        \\<td>One | Two</td>
+        \\</tr>
+        \\</table>
+        \\
+    );
+}
+
+test "table with pipes in code spans" {
+    try testRender(
+        \\| `|` | Bitwise _OR_ |
+        \\| `||` | Combines error sets |
+        \\| `` `||` `` | Escaped version |
+        \\| ` ``||`` ` | Another escaped version |
+        \\| `Oops unterminated code span |
+        \\
+    ,
+        \\<table>
+        \\<tr>
+        \\<td><code>|</code></td>
+        \\<td>Bitwise <em>OR</em></td>
+        \\</tr>
+        \\<tr>
+        \\<td><code>||</code></td>
+        \\<td>Combines error sets</td>
+        \\</tr>
+        \\<tr>
+        \\<td><code>`||`</code></td>
+        \\<td>Escaped version</td>
+        \\</tr>
+        \\<tr>
+        \\<td><code>``||``</code></td>
+        \\<td>Another escaped version</td>
+        \\</tr>
+        \\</table>
+        \\<p>| <code>Oops unterminated code span |</code></p>
+        \\
+    );
+}
+
+test "tables require leading and trailing pipes" {
+    try testRender(
+        \\Not | a | table
+        \\
+        \\| But | this | is |
+        \\
+    ,
+        \\<p>Not | a | table</p>
+        \\<table>
+        \\<tr>
+        \\<td>But</td>
+        \\<td>this</td>
+        \\<td>is</td>
+        \\</tr>
+        \\</table>
+        \\
+    );
+}
+
+test "headings" {
+    try testRender(
+        \\# Level one
+        \\## Level two
+        \\### Level three
+        \\#### Level four
+        \\##### Level five
+        \\###### Level six
+        \\####### Not a heading
+        \\
+    ,
+        \\<h1>Level one</h1>
+        \\<h2>Level two</h2>
+        \\<h3>Level three</h3>
+        \\<h4>Level four</h4>
+        \\<h5>Level five</h5>
+        \\<h6>Level six</h6>
+        \\<p>####### Not a heading</p>
+        \\
+    );
+}
+
+test "headings with inline content" {
+    try testRender(
+        \\# Outline of `std.zig`
+        \\## **Important** notes
+        \\### ***Nested* inline content**
+        \\
+    ,
+        \\<h1>Outline of <code>std.zig</code></h1>
+        \\<h2><strong>Important</strong> notes</h2>
+        \\<h3><strong><em>Nested</em> inline content</strong></h3>
+        \\
+    );
+}
+
+test "code blocks" {
+    try testRender(
+        \\```
+        \\Hello, world!
+        \\This is some code.
+        \\```
+        \\``` zig test
+        \\const std = @import("std");
+        \\
+        \\test {
+        \\    try std.testing.expect(2 + 2 == 4);
+        \\}
+        \\```
+        \\
+    ,
+        \\<pre><code>Hello, world!
+        \\This is some code.
+        \\</code></pre>
+        \\<pre><code class="zig test">const std = @import(&quot;std&quot;);
+        \\
+        \\test {
+        \\    try std.testing.expect(2 + 2 == 4);
+        \\}
+        \\</code></pre>
+        \\
+    );
+}
+
+test "blockquotes" {
+    try testRender(
+        \\> > You miss 100% of the shots you don't take.
+        \\> >
+        \\> > ~ Wayne Gretzky
+        \\>
+        \\> ~ Michael Scott
+        \\
+    ,
+        \\<blockquote>
+        \\<blockquote>
+        \\<p>You miss 100% of the shots you don't take.</p>
+        \\<p>~ Wayne Gretzky</p>
+        \\</blockquote>
+        \\<p>~ Michael Scott</p>
+        \\</blockquote>
+        \\
+    );
+}
+
+test "blockquote lazy continuation lines" {
+    try testRender(
+        \\>>>>Deeply nested blockquote
+        \\>>which continues on another line
+        \\and then yet another one.
+        \\>>
+        \\>> But now two of them have been closed.
+        \\
+        \\And then there were none.
+        \\
+    ,
+        \\<blockquote>
+        \\<blockquote>
+        \\<blockquote>
+        \\<blockquote>
+        \\<p>Deeply nested blockquote
+        \\which continues on another line
+        \\and then yet another one.</p>
+        \\</blockquote>
+        \\</blockquote>
+        \\<p>But now two of them have been closed.</p>
+        \\</blockquote>
+        \\</blockquote>
+        \\<p>And then there were none.</p>
+        \\
+    );
+}
+
+test "paragraphs" {
+    try testRender(
+        \\Paragraph one.
+        \\
+        \\Paragraph two.
+        \\Still in the paragraph.
+        \\    So is this.
+        \\
+        \\
+        \\
+        \\
+        \\ Last paragraph.
+        \\
+    ,
+        \\<p>Paragraph one.</p>
+        \\<p>Paragraph two.
+        \\Still in the paragraph.
+        \\So is this.</p>
+        \\<p>Last paragraph.</p>
+        \\
+    );
+}
+
+test "thematic breaks" {
+    try testRender(
+        \\---
+        \\***
+        \\___
+        \\          ---
+        \\ - - - - - - - - - - -
+        \\
+    ,
+        \\<hr />
+        \\<hr />
+        \\<hr />
+        \\<hr />
+        \\<hr />
+        \\
+    );
+}
+
+test "links" {
+    try testRender(
+        \\[Link](https://example.com)
+        \\[Link *with inlines*](https://example.com)
+        \\[Nested parens](https://example.com/nested(parens(inside)))
+        \\[Escaped parens](https://example.com/\)escaped\()
+        \\[Line break in target](test\
+        \\target)
+        \\
+    ,
+        \\<p><a href="https://example.com">Link</a>
+        \\<a href="https://example.com">Link <em>with inlines</em></a>
+        \\<a href="https://example.com/nested(parens(inside))">Nested parens</a>
+        \\<a href="https://example.com/)escaped(">Escaped parens</a>
+        \\<a href="test\
+        \\target">Line break in target</a></p>
+        \\
+    );
+}
+
+test "images" {
+    try testRender(
+        \\![Alt text](https://example.com/image.png)
+        \\![Alt text *with inlines*](https://example.com/image.png)
+        \\![Nested parens](https://example.com/nested(parens(inside)).png)
+        \\![Escaped parens](https://example.com/\)escaped\(.png)
+        \\![Line break in target](test\
+        \\target)
+        \\
+    ,
+        \\<p><img src="https://example.com/image.png" alt="Alt text" />
+        \\<img src="https://example.com/image.png" alt="Alt text with inlines" />
+        \\<img src="https://example.com/nested(parens(inside)).png" alt="Nested parens" />
+        \\<img src="https://example.com/)escaped(.png" alt="Escaped parens" />
+        \\<img src="test\
+        \\target" alt="Line break in target" /></p>
+        \\
+    );
+}
+
+test "emphasis" {
+    try testRender(
+        \\*Emphasis.*
+        \\**Strong.**
+        \\***Strong emphasis.***
+        \\****More...****
+        \\*****MORE...*****
+        \\******Even more...******
+        \\*******OK, this is enough.*******
+        \\
+    ,
+        \\<p><em>Emphasis.</em>
+        \\<strong>Strong.</strong>
+        \\<em><strong>Strong emphasis.</strong></em>
+        \\<em><strong><em>More...</em></strong></em>
+        \\<em><strong><strong>MORE...</strong></strong></em>
+        \\<em><strong><em><strong>Even more...</strong></em></strong></em>
+        \\<em><strong><em><strong><em>OK, this is enough.</em></strong></em></strong></em></p>
+        \\
+    );
+    try testRender(
+        \\_Emphasis._
+        \\__Strong.__
+        \\___Strong emphasis.___
+        \\____More...____
+        \\_____MORE..._____
+        \\______Even more...______
+        \\_______OK, this is enough._______
+        \\
+    ,
+        \\<p><em>Emphasis.</em>
+        \\<strong>Strong.</strong>
+        \\<em><strong>Strong emphasis.</strong></em>
+        \\<em><strong><em>More...</em></strong></em>
+        \\<em><strong><strong>MORE...</strong></strong></em>
+        \\<em><strong><em><strong>Even more...</strong></em></strong></em>
+        \\<em><strong><em><strong><em>OK, this is enough.</em></strong></em></strong></em></p>
+        \\
+    );
+}
+
+test "nested emphasis" {
+    try testRender(
+        \\**Hello, *world!***
+        \\*Hello, **world!***
+        \\**Hello, _world!_**
+        \\_Hello, **world!**_
+        \\*Hello, **nested** *world!**
+        \\***Hello,* world!**
+        \\__**Hello, world!**__
+        \\****Hello,** world!**
+        \\__Hello,_ world!_
+        \\*Test**123*
+        \\__Test____123__
+        \\
+    ,
+        \\<p><strong>Hello, <em>world!</em></strong>
+        \\<em>Hello, <strong>world!</strong></em>
+        \\<strong>Hello, <em>world!</em></strong>
+        \\<em>Hello, <strong>world!</strong></em>
+        \\<em>Hello, <strong>nested</strong> <em>world!</em></em>
+        \\<strong><em>Hello,</em> world!</strong>
+        \\<strong><strong>Hello, world!</strong></strong>
+        \\<strong><strong>Hello,</strong> world!</strong>
+        \\<em><em>Hello,</em> world!</em>
+        \\<em>Test</em><em>123</em>
+        \\<strong>Test____123</strong></p>
+        \\
+    );
+}
+
+test "emphasis precedence" {
+    try testRender(
+        \\*First one _wins*_.
+        \\_*No other __rule matters.*_
+        \\
+    ,
+        \\<p><em>First one _wins</em>_.
+        \\<em><em>No other __rule matters.</em></em></p>
+        \\
+    );
+}
+
+test "emphasis open and close" {
+    try testRender(
+        \\Cannot open: *
+        \\Cannot open: _
+        \\*Cannot close: *
+        \\_Cannot close: _
+        \\
+        \\foo*bar*baz
+        \\foo_bar_baz
+        \\foo**bar**baz
+        \\foo__bar__baz
+        \\
+    ,
+        \\<p>Cannot open: *
+        \\Cannot open: _
+        \\*Cannot close: *
+        \\_Cannot close: _</p>
+        \\<p>foo<em>bar</em>baz
+        \\foo_bar_baz
+        \\foo<strong>bar</strong>baz
+        \\foo__bar__baz</p>
+        \\
+    );
+}
+
+test "code spans" {
+    try testRender(
+        \\`Hello, world!`
+        \\```Multiple `backticks` can be used.```
+        \\`**This** does not produce emphasis.`
+        \\`` `Backtick enclosed string.` ``
+        \\`Delimiter lengths ```must``` match.`
+        \\
+        \\Unterminated ``code...
+        \\
+        \\Weird empty code span: `
+        \\
+        \\**Very important code: `hi`**
+        \\
+    ,
+        \\<p><code>Hello, world!</code>
+        \\<code>Multiple `backticks` can be used.</code>
+        \\<code>**This** does not produce emphasis.</code>
+        \\<code>`Backtick enclosed string.`</code>
+        \\<code>Delimiter lengths ```must``` match.</code></p>
+        \\<p>Unterminated <code>code...</code></p>
+        \\<p>Weird empty code span: <code></code></p>
+        \\<p><strong>Very important code: <code>hi</code></strong></p>
+        \\
+    );
+}
+
+test "backslash escapes" {
+    try testRender(
+        \\Not \*emphasized\*.
+        \\Literal \\backslashes\\.
+        \\Not code: \`hi\`.
+        \\\# Not a title.
+        \\#\# Also not a title.
+        \\\> Not a blockquote.
+        \\\- Not a list item.
+        \\\| Not a table. |
+        \\| Also not a table. \|
+        \\Any \punctuation\ characte\r can be escaped:
+        \\\!\"\#\$\%\&\'\(\)\*\+\,\-\.\/\:\;\<\=\>\?\@\[\\\]\^\_\`\{\|\}\~
+        \\
+    ,
+        \\<p>Not *emphasized*.
+        \\Literal \backslashes\.
+        \\Not code: `hi`.
+        \\# Not a title.
+        \\## Also not a title.
+        \\&gt; Not a blockquote.
+        \\- Not a list item.
+        \\| Not a table. |
+        \\| Also not a table. |
+        \\Any \punctuation\ characte\r can be escaped:
+        \\!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\]^_`{|}~</p>
+        \\
+    );
+}
+
+test "hard line breaks" {
+    try testRender(
+        \\The iguana sits\
+        \\Perched atop a short desk chair\
+        \\Writing code in Zig
+        \\
+    ,
+        \\<p>The iguana sits<br />
+        \\Perched atop a short desk chair<br />
+        \\Writing code in Zig</p>
+        \\
+    );
+}
+
+test "Unicode handling" {
+    // Null bytes must be replaced.
+    try testRender("\x00\x00\x00", "<p>\u{FFFD}\u{FFFD}\u{FFFD}</p>\n");
+
+    // Invalid UTF-8 must be replaced.
+    try testRender("\xC0\x80\xE0\x80\x80\xF0\x80\x80\x80", "<p>\u{FFFD}\u{FFFD}\u{FFFD}</p>\n");
+    try testRender("\xED\xA0\x80\xED\xBF\xBF", "<p>\u{FFFD}\u{FFFD}</p>\n");
+
+    // Incomplete UTF-8 must be replaced.
+    try testRender("\xE2\x82", "<p>\u{FFFD}</p>\n");
+}
+
+fn testRender(input: []const u8, expected: []const u8) !void {
+    var parser = try Parser.init(testing.allocator);
+    defer parser.deinit();
+
+    var lines = std.mem.split(u8, input, "\n");
+    while (lines.next()) |line| {
+        try parser.feedLine(line);
+    }
+    var doc = try parser.endInput();
+    defer doc.deinit(testing.allocator);
+
+    var actual = std.ArrayList(u8).init(testing.allocator);
+    defer actual.deinit();
+    try doc.render(actual.writer());
+
+    try testing.expectEqualStrings(expected, actual.items);
+}

--- a/src/markdown/Document.zig
+++ b/src/markdown/Document.zig
@@ -1,0 +1,192 @@
+//! An abstract tree representation of a Markdown document.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const assert = std.debug.assert;
+const Allocator = std.mem.Allocator;
+const Renderer = @import("renderer.zig").Renderer;
+
+nodes: Node.List.Slice,
+extra: []u32,
+string_bytes: []u8,
+
+const Document = @This();
+
+pub const Node = struct {
+    tag: Tag,
+    data: Data,
+
+    pub const Index = enum(u32) {
+        root = 0,
+        _,
+    };
+    pub const List = std.MultiArrayList(Node);
+
+    pub const Tag = enum {
+        /// Data is `container`.
+        root,
+
+        // Blocks
+        /// Data is `list`.
+        list,
+        /// Data is `list_item`.
+        list_item,
+        /// Data is `container`.
+        table,
+        /// Data is `container`.
+        table_row,
+        /// Data is `table_cell`.
+        table_cell,
+        /// Data is `heading`.
+        heading,
+        /// Data is `code_block`.
+        code_block,
+        /// Data is `container`.
+        blockquote,
+        /// Data is `container`.
+        paragraph,
+        /// Data is `none`.
+        thematic_break,
+
+        // Inlines
+        /// Data is `link`.
+        link,
+        /// Data is `link`.
+        image,
+        /// Data is `container`.
+        strong,
+        /// Data is `container`.
+        emphasis,
+        /// Data is `text`.
+        code_span,
+        /// Data is `text`.
+        text,
+        /// Data is `none`.
+        line_break,
+    };
+
+    pub const Data = union {
+        none: void,
+        container: struct {
+            children: ExtraIndex,
+        },
+        text: struct {
+            content: StringIndex,
+        },
+        list: struct {
+            start: ListStart,
+            children: ExtraIndex,
+        },
+        list_item: struct {
+            tight: bool,
+            children: ExtraIndex,
+        },
+        table_cell: struct {
+            info: packed struct {
+                alignment: TableCellAlignment,
+                header: bool,
+            },
+            children: ExtraIndex,
+        },
+        heading: struct {
+            /// Between 1 and 6, inclusive.
+            level: u3,
+            children: ExtraIndex,
+        },
+        code_block: struct {
+            tag: StringIndex,
+            content: StringIndex,
+        },
+        link: struct {
+            target: StringIndex,
+            children: ExtraIndex,
+        },
+
+        comptime {
+            // In Debug and ReleaseSafe builds, there may be hidden extra fields
+            // included for safety checks. Without such safety checks enabled,
+            // we always want this union to be 8 bytes.
+            if (builtin.mode != .Debug and builtin.mode != .ReleaseSafe) {
+                assert(@sizeOf(Data) == 8);
+            }
+        }
+    };
+
+    /// The starting number of a list. This is either a number between 0 and
+    /// 999,999,999, inclusive, or `unordered` to indicate an unordered list.
+    pub const ListStart = enum(u30) {
+        // When https://github.com/ziglang/zig/issues/104 is implemented, this
+        // type can be more naturally expressed as ?u30. As it is, we want
+        // values to fit within 4 bytes, so ?u30 does not yet suffice for
+        // storage.
+        unordered = std.math.maxInt(u30),
+        _,
+
+        pub fn asNumber(start: ListStart) ?u30 {
+            if (start == .unordered) return null;
+            assert(@intFromEnum(start) <= 999_999_999);
+            return @intFromEnum(start);
+        }
+    };
+
+    pub const TableCellAlignment = enum {
+        unset,
+        left,
+        center,
+        right,
+    };
+
+    /// Trailing: `len` times `Node.Index`
+    pub const Children = struct {
+        len: u32,
+    };
+};
+
+pub const ExtraIndex = enum(u32) { _ };
+
+/// The index of a null-terminated string in `string_bytes`.
+pub const StringIndex = enum(u32) {
+    empty = 0,
+    _,
+};
+
+pub fn deinit(doc: *Document, allocator: Allocator) void {
+    doc.nodes.deinit(allocator);
+    allocator.free(doc.extra);
+    allocator.free(doc.string_bytes);
+    doc.* = undefined;
+}
+
+/// Renders a document directly to a writer using the default renderer.
+pub fn render(doc: Document, writer: anytype) @TypeOf(writer).Error!void {
+    const renderer: Renderer(@TypeOf(writer), void) = .{ .context = {} };
+    try renderer.render(doc, writer);
+}
+
+pub fn ExtraData(comptime T: type) type {
+    return struct { data: T, end: usize };
+}
+
+pub fn extraData(doc: Document, comptime T: type, index: ExtraIndex) ExtraData(T) {
+    const fields = @typeInfo(T).Struct.fields;
+    var i: usize = @intFromEnum(index);
+    var result: T = undefined;
+    inline for (fields) |field| {
+        @field(result, field.name) = switch (field.type) {
+            u32 => doc.extra[i],
+            else => @compileError("bad field type"),
+        };
+        i += 1;
+    }
+    return .{ .data = result, .end = i };
+}
+
+pub fn extraChildren(doc: Document, index: ExtraIndex) []const Node.Index {
+    const children = doc.extraData(Node.Children, index);
+    return @ptrCast(doc.extra[children.end..][0..children.data.len]);
+}
+
+pub fn string(doc: Document, index: StringIndex) [:0]const u8 {
+    const start = @intFromEnum(index);
+    return std.mem.span(@as([*:0]u8, @ptrCast(doc.string_bytes[start..].ptr)));
+}

--- a/src/markdown/Parser.zig
+++ b/src/markdown/Parser.zig
@@ -1,0 +1,1500 @@
+//! A Markdown parser producing `Document`s.
+//!
+//! The parser operates at two levels: at the outer level, the parser accepts
+//! the content of an input document line by line and begins building the _block
+//! structure_ of the document. This creates a stack of currently open blocks.
+//!
+//! When the parser detects the end of a block, it closes the block, popping it
+//! from the open block stack and completing any additional parsing of the
+//! block's content. For blocks which contain parseable inline content, this
+//! invokes the inner level of the parser, handling the _inline structure_ of
+//! the block.
+//!
+//! Inline parsing scans through the collected inline content of a block. When
+//! it encounters a character that could indicate the beginning of an inline, it
+//! either handles the inline right away (if possible) or adds it to a pending
+//! inlines stack. When an inline is completed, it is added to a list of
+//! completed inlines, which (along with any surrounding text nodes) will become
+//! the children of the parent inline or the block whose inline content is being
+//! parsed.
+
+const std = @import("std");
+const mem = std.mem;
+const assert = std.debug.assert;
+const isWhitespace = std.ascii.isWhitespace;
+const Allocator = mem.Allocator;
+const expectEqual = std.testing.expectEqual;
+const Document = @import("Document.zig");
+const Node = Document.Node;
+const ExtraIndex = Document.ExtraIndex;
+const ExtraData = Document.ExtraData;
+const StringIndex = Document.StringIndex;
+
+nodes: Node.List = .{},
+extra: std.ArrayListUnmanaged(u32) = .{},
+scratch_extra: std.ArrayListUnmanaged(u32) = .{},
+string_bytes: std.ArrayListUnmanaged(u8) = .{},
+scratch_string: std.ArrayListUnmanaged(u8) = .{},
+pending_blocks: std.ArrayListUnmanaged(Block) = .{},
+allocator: Allocator,
+
+const Parser = @This();
+
+/// An arbitrary limit on the maximum number of columns in a table so that
+/// table-related metadata maintained by the parser does not require dynamic
+/// memory allocation.
+const max_table_columns = 128;
+
+/// A block element which is still receiving children.
+const Block = struct {
+    tag: Tag,
+    data: Data,
+    extra_start: usize,
+    string_start: usize,
+
+    const Tag = enum {
+        /// Data is `list`.
+        list,
+        /// Data is `list_item`.
+        list_item,
+        /// Data is `table`.
+        table,
+        /// Data is `none`.
+        table_row,
+        /// Data is `heading`.
+        heading,
+        /// Data is `code_block`.
+        code_block,
+        /// Data is `none`.
+        blockquote,
+        /// Data is `none`.
+        paragraph,
+        /// Data is `none`.
+        thematic_break,
+    };
+
+    const Data = union {
+        none: void,
+        list: struct {
+            marker: ListMarker,
+            /// Between 0 and 999,999,999, inclusive.
+            start: u30,
+            tight: bool,
+            last_line_blank: bool = false,
+        },
+        list_item: struct {
+            continuation_indent: usize,
+        },
+        table: struct {
+            column_alignments: std.BoundedArray(Node.TableCellAlignment, max_table_columns) = .{},
+        },
+        heading: struct {
+            /// Between 1 and 6, inclusive.
+            level: u3,
+        },
+        code_block: struct {
+            tag: StringIndex,
+            fence_len: usize,
+            indent: usize,
+        },
+
+        const ListMarker = enum {
+            @"-",
+            @"*",
+            @"+",
+            number_dot,
+            number_paren,
+        };
+    };
+
+    const ContentType = enum {
+        blocks,
+        inlines,
+        raw_inlines,
+        nothing,
+    };
+
+    fn canAccept(b: Block) ContentType {
+        return switch (b.tag) {
+            .list,
+            .list_item,
+            .table,
+            .blockquote,
+            => .blocks,
+
+            .heading,
+            .paragraph,
+            => .inlines,
+
+            .code_block,
+            => .raw_inlines,
+
+            .table_row,
+            .thematic_break,
+            => .nothing,
+        };
+    }
+
+    /// Attempts to continue `b` using the contents of `line`. If successful,
+    /// returns the remaining portion of `line` to be considered part of `b`
+    /// (e.g. for a blockquote, this would be everything except the leading
+    /// `>`). If unsuccessful, returns null.
+    fn match(b: Block, line: []const u8) ?[]const u8 {
+        const unindented = mem.trimLeft(u8, line, " \t");
+        const indent = line.len - unindented.len;
+        return switch (b.tag) {
+            .list => line,
+            .list_item => if (indent >= b.data.list_item.continuation_indent)
+                line[b.data.list_item.continuation_indent..]
+            else if (unindented.len == 0)
+                // Blank lines should not close list items, since there may be
+                // more indented contents to follow after the blank line.
+                ""
+            else
+                null,
+            .table => if (unindented.len > 0) unindented else null,
+            .table_row => null,
+            .heading => null,
+            .code_block => code_block: {
+                const trimmed = mem.trimRight(u8, unindented, " \t");
+                if (mem.indexOfNone(u8, trimmed, "`") != null or trimmed.len != b.data.code_block.fence_len) {
+                    const effective_indent = @min(indent, b.data.code_block.indent);
+                    break :code_block line[effective_indent..];
+                } else {
+                    break :code_block null;
+                }
+            },
+            .blockquote => if (mem.startsWith(u8, unindented, ">"))
+                unindented[1..]
+            else
+                null,
+            .paragraph => if (unindented.len > 0) unindented else null,
+            .thematic_break => null,
+        };
+    }
+};
+
+pub fn init(allocator: Allocator) Allocator.Error!Parser {
+    var p: Parser = .{ .allocator = allocator };
+    try p.nodes.append(allocator, .{
+        .tag = .root,
+        .data = undefined,
+    });
+    try p.string_bytes.append(allocator, 0);
+    return p;
+}
+
+pub fn deinit(p: *Parser) void {
+    p.nodes.deinit(p.allocator);
+    p.extra.deinit(p.allocator);
+    p.scratch_extra.deinit(p.allocator);
+    p.string_bytes.deinit(p.allocator);
+    p.scratch_string.deinit(p.allocator);
+    p.pending_blocks.deinit(p.allocator);
+    p.* = undefined;
+}
+
+/// Accepts a single line of content. `line` should not have a trailing line
+/// ending character.
+pub fn feedLine(p: *Parser, line: []const u8) Allocator.Error!void {
+    var rest_line = line;
+    const first_unmatched = for (p.pending_blocks.items, 0..) |b, i| {
+        if (b.match(rest_line)) |rest| {
+            rest_line = rest;
+        } else {
+            break i;
+        }
+    } else p.pending_blocks.items.len;
+
+    const in_code_block = p.pending_blocks.items.len > 0 and
+        p.pending_blocks.getLast().tag == .code_block;
+    const code_block_end = in_code_block and
+        first_unmatched + 1 == p.pending_blocks.items.len;
+    // New blocks cannot be started if we are actively inside a code block or
+    // are just closing one (to avoid interpreting the closing ``` as a new code
+    // block start).
+    var maybe_block_start = if (!in_code_block or first_unmatched + 2 <= p.pending_blocks.items.len)
+        try p.startBlock(rest_line)
+    else
+        null;
+
+    // This is a lazy continuation line if there are no new blocks to open and
+    // the last open block is a paragraph.
+    if (maybe_block_start == null and
+        !isBlank(rest_line) and
+        p.pending_blocks.items.len > 0 and
+        p.pending_blocks.getLast().tag == .paragraph)
+    {
+        try p.addScratchStringLine(rest_line);
+        return;
+    }
+
+    // If a new block needs to be started, any paragraph needs to be closed,
+    // even though this isn't detected as part of the closing condition for
+    // paragraphs.
+    if (maybe_block_start != null and
+        p.pending_blocks.items.len > 0 and
+        p.pending_blocks.getLast().tag == .paragraph)
+    {
+        try p.closeLastBlock();
+    }
+
+    while (p.pending_blocks.items.len > first_unmatched) {
+        try p.closeLastBlock();
+    }
+
+    while (maybe_block_start) |block_start| : (maybe_block_start = try p.startBlock(rest_line)) {
+        try p.appendBlockStart(block_start);
+        // There may be more blocks to start within the same line.
+        rest_line = block_start.rest;
+        // Headings may only contain inline content.
+        if (block_start.tag == .heading) break;
+        // An opening code fence does not contain any additional block or inline
+        // content to process.
+        if (block_start.tag == .code_block) return;
+    }
+
+    // Do not append the end of a code block (```) as textual content.
+    if (code_block_end) return;
+
+    const can_accept = if (p.pending_blocks.getLastOrNull()) |last_pending_block|
+        last_pending_block.canAccept()
+    else
+        .blocks;
+    const rest_line_trimmed = mem.trimLeft(u8, rest_line, " \t");
+    switch (can_accept) {
+        .blocks => {
+            // If we're inside a list item and the rest of the line is blank, it
+            // means that any subsequent child of the list item (or subsequent
+            // item in the list) will cause the containing list to be considered
+            // loose. However, we can't immediately declare that the list is
+            // loose, since we might just be looking at a blank line after the
+            // end of the last item in the list. The final determination will be
+            // made when appending the next child of the list or list item.
+            const maybe_containing_list = if (p.pending_blocks.items.len > 0 and p.pending_blocks.getLast().tag == .list_item)
+                &p.pending_blocks.items[p.pending_blocks.items.len - 2]
+            else
+                null;
+
+            if (rest_line_trimmed.len > 0) {
+                try p.appendBlockStart(.{
+                    .tag = .paragraph,
+                    .data = .{ .none = {} },
+                    .rest = undefined,
+                });
+                try p.addScratchStringLine(rest_line_trimmed);
+            }
+
+            if (maybe_containing_list) |containing_list| {
+                containing_list.data.list.last_line_blank = rest_line_trimmed.len == 0;
+            }
+        },
+        .inlines => try p.addScratchStringLine(rest_line_trimmed),
+        .raw_inlines => try p.addScratchStringLine(rest_line),
+        .nothing => {},
+    }
+}
+
+/// Completes processing of the input and returns the parsed document.
+pub fn endInput(p: *Parser) Allocator.Error!Document {
+    while (p.pending_blocks.items.len > 0) {
+        try p.closeLastBlock();
+    }
+    // There should be no inline content pending after closing the last open
+    // block.
+    assert(p.scratch_string.items.len == 0);
+
+    const children = try p.addExtraChildren(@ptrCast(p.scratch_extra.items));
+    p.nodes.items(.data)[0] = .{ .container = .{ .children = children } };
+    p.scratch_string.items.len = 0;
+    p.scratch_extra.items.len = 0;
+
+    var nodes = p.nodes.toOwnedSlice();
+    errdefer nodes.deinit(p.allocator);
+    const extra = try p.extra.toOwnedSlice(p.allocator);
+    errdefer p.allocator.free(extra);
+    const string_bytes = try p.string_bytes.toOwnedSlice(p.allocator);
+    errdefer p.allocator.free(string_bytes);
+
+    return .{
+        .nodes = nodes,
+        .extra = extra,
+        .string_bytes = string_bytes,
+    };
+}
+
+/// Data describing the start of a new block element.
+const BlockStart = struct {
+    tag: Tag,
+    data: Data,
+    rest: []const u8,
+
+    const Tag = enum {
+        /// Data is `list_item`.
+        list_item,
+        /// Data is `table_row`.
+        table_row,
+        /// Data is `heading`.
+        heading,
+        /// Data is `code_block`.
+        code_block,
+        /// Data is `none`.
+        blockquote,
+        /// Data is `none`.
+        paragraph,
+        /// Data is `none`.
+        thematic_break,
+    };
+
+    const Data = union {
+        none: void,
+        list_item: struct {
+            marker: Block.Data.ListMarker,
+            number: u30,
+            continuation_indent: usize,
+        },
+        table_row: struct {
+            cells: std.BoundedArray([]const u8, max_table_columns),
+        },
+        heading: struct {
+            /// Between 1 and 6, inclusive.
+            level: u3,
+        },
+        code_block: struct {
+            tag: StringIndex,
+            fence_len: usize,
+            indent: usize,
+        },
+    };
+};
+
+fn appendBlockStart(p: *Parser, block_start: BlockStart) !void {
+    if (p.pending_blocks.getLastOrNull()) |last_pending_block| {
+        // Close the last block if it is a list and the new block is not a list item
+        // or not of the same marker type.
+        const should_close_list = last_pending_block.tag == .list and
+            (block_start.tag != .list_item or
+            block_start.data.list_item.marker != last_pending_block.data.list.marker);
+        // The last block should also be closed if the new block is not a table
+        // row, which is the only allowed child of a table.
+        const should_close_table = last_pending_block.tag == .table and
+            block_start.tag != .table_row;
+        if (should_close_list or should_close_table) {
+            try p.closeLastBlock();
+        }
+    }
+
+    if (p.pending_blocks.getLastOrNull()) |last_pending_block| {
+        // If the last block is a list or list item, check for tightness based
+        // on the last line.
+        const maybe_containing_list = switch (last_pending_block.tag) {
+            .list => &p.pending_blocks.items[p.pending_blocks.items.len - 1],
+            .list_item => &p.pending_blocks.items[p.pending_blocks.items.len - 2],
+            else => null,
+        };
+        if (maybe_containing_list) |containing_list| {
+            if (containing_list.data.list.last_line_blank) {
+                containing_list.data.list.tight = false;
+            }
+        }
+    }
+
+    // Start a new list if the new block is a list item and there is no
+    // containing list yet.
+    if (block_start.tag == .list_item and
+        (p.pending_blocks.items.len == 0 or p.pending_blocks.getLast().tag != .list))
+    {
+        try p.pending_blocks.append(p.allocator, .{
+            .tag = .list,
+            .data = .{ .list = .{
+                .marker = block_start.data.list_item.marker,
+                .start = block_start.data.list_item.number,
+                .tight = true,
+            } },
+            .string_start = p.scratch_string.items.len,
+            .extra_start = p.scratch_extra.items.len,
+        });
+    }
+
+    if (block_start.tag == .table_row) {
+        // Likewise, table rows start a table implicitly.
+        if (p.pending_blocks.items.len == 0 or p.pending_blocks.getLast().tag != .table) {
+            try p.pending_blocks.append(p.allocator, .{
+                .tag = .table,
+                .data = .{ .table = .{
+                    .column_alignments = .{},
+                } },
+                .string_start = p.scratch_string.items.len,
+                .extra_start = p.scratch_extra.items.len,
+            });
+        }
+
+        const current_row = p.scratch_extra.items.len - p.pending_blocks.getLast().extra_start;
+        if (current_row <= 1) {
+            if (parseTableHeaderDelimiter(block_start.data.table_row.cells)) |alignments| {
+                p.pending_blocks.items[p.pending_blocks.items.len - 1].data.table.column_alignments = alignments;
+                if (current_row == 1) {
+                    // We need to go back and mark the header row and its column
+                    // alignments.
+                    const datas = p.nodes.items(.data);
+                    const header_data = datas[p.scratch_extra.getLast()];
+                    for (p.extraChildren(header_data.container.children), 0..) |header_cell, i| {
+                        const alignment = if (i < alignments.len) alignments.buffer[i] else .unset;
+                        const cell_data = &datas[@intFromEnum(header_cell)].table_cell;
+                        cell_data.info.alignment = alignment;
+                        cell_data.info.header = true;
+                    }
+                }
+                return;
+            }
+        }
+    }
+
+    const tag: Block.Tag, const data: Block.Data = switch (block_start.tag) {
+        .list_item => .{ .list_item, .{ .list_item = .{
+            .continuation_indent = block_start.data.list_item.continuation_indent,
+        } } },
+        .table_row => .{ .table_row, .{ .none = {} } },
+        .heading => .{ .heading, .{ .heading = .{
+            .level = block_start.data.heading.level,
+        } } },
+        .code_block => .{ .code_block, .{ .code_block = .{
+            .tag = block_start.data.code_block.tag,
+            .fence_len = block_start.data.code_block.fence_len,
+            .indent = block_start.data.code_block.indent,
+        } } },
+        .blockquote => .{ .blockquote, .{ .none = {} } },
+        .paragraph => .{ .paragraph, .{ .none = {} } },
+        .thematic_break => .{ .thematic_break, .{ .none = {} } },
+    };
+
+    try p.pending_blocks.append(p.allocator, .{
+        .tag = tag,
+        .data = data,
+        .string_start = p.scratch_string.items.len,
+        .extra_start = p.scratch_extra.items.len,
+    });
+
+    if (tag == .table_row) {
+        // Table rows are unique, since we already have all the children
+        // available in the BlockStart. We can immediately parse and append
+        // these children now.
+        const containing_table = p.pending_blocks.items[p.pending_blocks.items.len - 2];
+        const column_alignments = containing_table.data.table.column_alignments.slice();
+        for (block_start.data.table_row.cells.slice(), 0..) |cell_content, i| {
+            const cell_children = try p.parseInlines(cell_content);
+            const alignment = if (i < column_alignments.len) column_alignments[i] else .unset;
+            const cell = try p.addNode(.{
+                .tag = .table_cell,
+                .data = .{ .table_cell = .{
+                    .info = .{
+                        .alignment = alignment,
+                        .header = false,
+                    },
+                    .children = cell_children,
+                } },
+            });
+            try p.addScratchExtraNode(cell);
+        }
+    }
+}
+
+fn startBlock(p: *Parser, line: []const u8) !?BlockStart {
+    const unindented = mem.trimLeft(u8, line, " \t");
+    const indent = line.len - unindented.len;
+    if (isThematicBreak(line)) {
+        // Thematic breaks take precedence over list items.
+        return .{
+            .tag = .thematic_break,
+            .data = .{ .none = {} },
+            .rest = "",
+        };
+    } else if (startListItem(unindented)) |list_item| {
+        return .{
+            .tag = .list_item,
+            .data = .{ .list_item = .{
+                .marker = list_item.marker,
+                .number = list_item.number,
+                .continuation_indent = list_item.continuation_indent,
+            } },
+            .rest = list_item.rest,
+        };
+    } else if (startTableRow(unindented)) |table_row| {
+        return .{
+            .tag = .table_row,
+            .data = .{ .table_row = .{
+                .cells = table_row.cells,
+            } },
+            .rest = "",
+        };
+    } else if (startHeading(unindented)) |heading| {
+        return .{
+            .tag = .heading,
+            .data = .{ .heading = .{
+                .level = heading.level,
+            } },
+            .rest = heading.rest,
+        };
+    } else if (try p.startCodeBlock(unindented)) |code_block| {
+        return .{
+            .tag = .code_block,
+            .data = .{ .code_block = .{
+                .tag = code_block.tag,
+                .fence_len = code_block.fence_len,
+                .indent = indent,
+            } },
+            .rest = "",
+        };
+    } else if (startBlockquote(unindented)) |rest| {
+        return .{
+            .tag = .blockquote,
+            .data = .{ .none = {} },
+            .rest = rest,
+        };
+    } else {
+        return null;
+    }
+}
+
+const ListItemStart = struct {
+    marker: Block.Data.ListMarker,
+    number: u30,
+    continuation_indent: usize,
+    rest: []const u8,
+};
+
+fn startListItem(unindented_line: []const u8) ?ListItemStart {
+    if (mem.startsWith(u8, unindented_line, "- ")) {
+        return .{
+            .marker = .@"-",
+            .number = undefined,
+            .continuation_indent = 2,
+            .rest = unindented_line[2..],
+        };
+    } else if (mem.startsWith(u8, unindented_line, "* ")) {
+        return .{
+            .marker = .@"*",
+            .number = undefined,
+            .continuation_indent = 2,
+            .rest = unindented_line[2..],
+        };
+    } else if (mem.startsWith(u8, unindented_line, "+ ")) {
+        return .{
+            .marker = .@"+",
+            .number = undefined,
+            .continuation_indent = 2,
+            .rest = unindented_line[2..],
+        };
+    }
+
+    const number_end = mem.indexOfNone(u8, unindented_line, "0123456789") orelse return null;
+    const after_number = unindented_line[number_end..];
+    const marker: Block.Data.ListMarker = if (mem.startsWith(u8, after_number, ". "))
+        .number_dot
+    else if (mem.startsWith(u8, after_number, ") "))
+        .number_paren
+    else
+        return null;
+    const number = std.fmt.parseInt(u30, unindented_line[0..number_end], 10) catch return null;
+    if (number > 999_999_999) return null;
+    return .{
+        .marker = marker,
+        .number = number,
+        .continuation_indent = number_end + 2,
+        .rest = after_number[2..],
+    };
+}
+
+const TableRowStart = struct {
+    cells: std.BoundedArray([]const u8, max_table_columns),
+};
+
+fn startTableRow(unindented_line: []const u8) ?TableRowStart {
+    if (!mem.startsWith(u8, unindented_line, "|") or
+        mem.endsWith(u8, unindented_line, "\\|") or
+        !mem.endsWith(u8, unindented_line, "|")) return null;
+
+    var cells: std.BoundedArray([]const u8, max_table_columns) = .{};
+    const table_row_content = unindented_line[1 .. unindented_line.len - 1];
+    var cell_start: usize = 0;
+    var i: usize = 0;
+    while (i < table_row_content.len) : (i += 1) {
+        switch (table_row_content[i]) {
+            '\\' => i += 1,
+            '|' => {
+                cells.append(table_row_content[cell_start..i]) catch return null;
+                cell_start = i + 1;
+            },
+            '`' => {
+                // Ignoring pipes in code spans allows table cells to contain
+                // code using ||, for example.
+                const open_start = i;
+                i = mem.indexOfNonePos(u8, table_row_content, i, "`") orelse return null;
+                const open_len = i - open_start;
+                while (mem.indexOfScalarPos(u8, table_row_content, i, '`')) |close_start| {
+                    i = mem.indexOfNonePos(u8, table_row_content, close_start, "`") orelse return null;
+                    const close_len = i - close_start;
+                    if (close_len == open_len) break;
+                } else return null;
+            },
+            else => {},
+        }
+    }
+    cells.append(table_row_content[cell_start..]) catch return null;
+
+    return .{ .cells = cells };
+}
+
+fn parseTableHeaderDelimiter(
+    row_cells: std.BoundedArray([]const u8, max_table_columns),
+) ?std.BoundedArray(Node.TableCellAlignment, max_table_columns) {
+    var alignments: std.BoundedArray(Node.TableCellAlignment, max_table_columns) = .{};
+    for (row_cells.slice()) |content| {
+        const alignment = parseTableHeaderDelimiterCell(content) orelse return null;
+        alignments.appendAssumeCapacity(alignment);
+    }
+    return alignments;
+}
+
+fn parseTableHeaderDelimiterCell(content: []const u8) ?Node.TableCellAlignment {
+    var state: enum {
+        before_rule,
+        after_left_anchor,
+        in_rule,
+        after_right_anchor,
+        after_rule,
+    } = .before_rule;
+    var left_anchor = false;
+    var right_anchor = false;
+    for (content) |c| {
+        switch (state) {
+            .before_rule => switch (c) {
+                ' ' => {},
+                ':' => {
+                    left_anchor = true;
+                    state = .after_left_anchor;
+                },
+                '-' => state = .in_rule,
+                else => return null,
+            },
+            .after_left_anchor => switch (c) {
+                '-' => state = .in_rule,
+                else => return null,
+            },
+            .in_rule => switch (c) {
+                '-' => {},
+                ':' => {
+                    right_anchor = true;
+                    state = .after_right_anchor;
+                },
+                ' ' => state = .after_rule,
+                else => return null,
+            },
+            .after_right_anchor => switch (c) {
+                ' ' => state = .after_rule,
+                else => return null,
+            },
+            .after_rule => switch (c) {
+                ' ' => {},
+                else => return null,
+            },
+        }
+    }
+
+    switch (state) {
+        .before_rule,
+        .after_left_anchor,
+        => return null,
+
+        .in_rule,
+        .after_right_anchor,
+        .after_rule,
+        => {},
+    }
+
+    return if (left_anchor and right_anchor)
+        .center
+    else if (left_anchor)
+        .left
+    else if (right_anchor)
+        .right
+    else
+        .unset;
+}
+
+test parseTableHeaderDelimiterCell {
+    try expectEqual(null, parseTableHeaderDelimiterCell(""));
+    try expectEqual(null, parseTableHeaderDelimiterCell("   "));
+    try expectEqual(.unset, parseTableHeaderDelimiterCell("-"));
+    try expectEqual(.unset, parseTableHeaderDelimiterCell(" - "));
+    try expectEqual(.unset, parseTableHeaderDelimiterCell("----"));
+    try expectEqual(.unset, parseTableHeaderDelimiterCell(" ---- "));
+    try expectEqual(null, parseTableHeaderDelimiterCell(":"));
+    try expectEqual(null, parseTableHeaderDelimiterCell("::"));
+    try expectEqual(.left, parseTableHeaderDelimiterCell(":-"));
+    try expectEqual(.left, parseTableHeaderDelimiterCell(" :----"));
+    try expectEqual(.center, parseTableHeaderDelimiterCell(":-:"));
+    try expectEqual(.center, parseTableHeaderDelimiterCell(":----:"));
+    try expectEqual(.center, parseTableHeaderDelimiterCell("   :----:   "));
+    try expectEqual(.right, parseTableHeaderDelimiterCell("-:"));
+    try expectEqual(.right, parseTableHeaderDelimiterCell("----:"));
+    try expectEqual(.right, parseTableHeaderDelimiterCell("  ----:  "));
+}
+
+const HeadingStart = struct {
+    level: u3,
+    rest: []const u8,
+};
+
+fn startHeading(unindented_line: []const u8) ?HeadingStart {
+    var level: u3 = 0;
+    return for (unindented_line, 0..) |c, i| {
+        switch (c) {
+            '#' => {
+                if (level == 6) break null;
+                level += 1;
+            },
+            ' ' => {
+                // We must have seen at least one # by this point, since
+                // unindented_line has no leading spaces.
+                assert(level > 0);
+                break .{
+                    .level = level,
+                    .rest = unindented_line[i + 1 ..],
+                };
+            },
+            else => break null,
+        }
+    } else null;
+}
+
+const CodeBlockStart = struct {
+    tag: StringIndex,
+    fence_len: usize,
+};
+
+fn startCodeBlock(p: *Parser, unindented_line: []const u8) !?CodeBlockStart {
+    var fence_len: usize = 0;
+    const tag_bytes = for (unindented_line, 0..) |c, i| {
+        switch (c) {
+            '`' => fence_len += 1,
+            else => break unindented_line[i..],
+        }
+    } else "";
+    // Code block tags may not contain backticks, since that would create
+    // potential confusion with inline code spans.
+    if (fence_len < 3 or mem.indexOfScalar(u8, tag_bytes, '`') != null) return null;
+    return .{
+        .tag = try p.addString(mem.trim(u8, tag_bytes, " ")),
+        .fence_len = fence_len,
+    };
+}
+
+fn startBlockquote(unindented_line: []const u8) ?[]const u8 {
+    return if (mem.startsWith(u8, unindented_line, ">"))
+        unindented_line[1..]
+    else
+        null;
+}
+
+fn isThematicBreak(line: []const u8) bool {
+    var char: ?u8 = null;
+    var count: usize = 0;
+    for (line) |c| {
+        switch (c) {
+            ' ' => {},
+            '-', '_', '*' => {
+                if (char != null and c != char.?) return false;
+                char = c;
+                count += 1;
+            },
+            else => return false,
+        }
+    }
+    return count >= 3;
+}
+
+fn closeLastBlock(p: *Parser) !void {
+    const b = p.pending_blocks.pop();
+    const node = switch (b.tag) {
+        .list => list: {
+            assert(b.string_start == p.scratch_string.items.len);
+
+            // Although tightness is parsed as a property of the list, it is
+            // stored at the list item level to make it possible to render each
+            // node without any context from its parents.
+            const list_items = p.scratch_extra.items[b.extra_start..];
+            const node_datas = p.nodes.items(.data);
+            if (!b.data.list.tight) {
+                for (list_items) |list_item| {
+                    node_datas[list_item].list_item.tight = false;
+                }
+            }
+
+            const children = try p.addExtraChildren(@ptrCast(list_items));
+            break :list try p.addNode(.{
+                .tag = .list,
+                .data = .{ .list = .{
+                    .start = switch (b.data.list.marker) {
+                        .number_dot, .number_paren => @enumFromInt(b.data.list.start),
+                        .@"-", .@"*", .@"+" => .unordered,
+                    },
+                    .children = children,
+                } },
+            });
+        },
+        .list_item => list_item: {
+            assert(b.string_start == p.scratch_string.items.len);
+            const children = try p.addExtraChildren(@ptrCast(p.scratch_extra.items[b.extra_start..]));
+            break :list_item try p.addNode(.{
+                .tag = .list_item,
+                .data = .{ .list_item = .{
+                    .tight = true,
+                    .children = children,
+                } },
+            });
+        },
+        .table => table: {
+            assert(b.string_start == p.scratch_string.items.len);
+            const children = try p.addExtraChildren(@ptrCast(p.scratch_extra.items[b.extra_start..]));
+            break :table try p.addNode(.{
+                .tag = .table,
+                .data = .{ .container = .{
+                    .children = children,
+                } },
+            });
+        },
+        .table_row => table_row: {
+            assert(b.string_start == p.scratch_string.items.len);
+            const children = try p.addExtraChildren(@ptrCast(p.scratch_extra.items[b.extra_start..]));
+            break :table_row try p.addNode(.{
+                .tag = .table_row,
+                .data = .{ .container = .{
+                    .children = children,
+                } },
+            });
+        },
+        .heading => heading: {
+            const children = try p.parseInlines(p.scratch_string.items[b.string_start..]);
+            break :heading try p.addNode(.{
+                .tag = .heading,
+                .data = .{ .heading = .{
+                    .level = b.data.heading.level,
+                    .children = children,
+                } },
+            });
+        },
+        .code_block => code_block: {
+            const content = try p.addString(p.scratch_string.items[b.string_start..]);
+            break :code_block try p.addNode(.{
+                .tag = .code_block,
+                .data = .{ .code_block = .{
+                    .tag = b.data.code_block.tag,
+                    .content = content,
+                } },
+            });
+        },
+        .blockquote => blockquote: {
+            assert(b.string_start == p.scratch_string.items.len);
+            const children = try p.addExtraChildren(@ptrCast(p.scratch_extra.items[b.extra_start..]));
+            break :blockquote try p.addNode(.{
+                .tag = .blockquote,
+                .data = .{ .container = .{
+                    .children = children,
+                } },
+            });
+        },
+        .paragraph => paragraph: {
+            const children = try p.parseInlines(p.scratch_string.items[b.string_start..]);
+            break :paragraph try p.addNode(.{
+                .tag = .paragraph,
+                .data = .{ .container = .{
+                    .children = children,
+                } },
+            });
+        },
+        .thematic_break => try p.addNode(.{
+            .tag = .thematic_break,
+            .data = .{ .none = {} },
+        }),
+    };
+    p.scratch_string.items.len = b.string_start;
+    p.scratch_extra.items.len = b.extra_start;
+    try p.addScratchExtraNode(node);
+}
+
+const InlineParser = struct {
+    parent: *Parser,
+    content: []const u8,
+    pos: usize = 0,
+    pending_inlines: std.ArrayListUnmanaged(PendingInline) = .{},
+    completed_inlines: std.ArrayListUnmanaged(CompletedInline) = .{},
+
+    const PendingInline = struct {
+        tag: Tag,
+        data: Data,
+        start: usize,
+
+        const Tag = enum {
+            /// Data is `emphasis`.
+            emphasis,
+            /// Data is `none`.
+            link,
+            /// Data is `none`.
+            image,
+        };
+
+        const Data = union {
+            none: void,
+            emphasis: struct {
+                underscore: bool,
+                run_len: usize,
+            },
+        };
+    };
+
+    const CompletedInline = struct {
+        node: Node.Index,
+        start: usize,
+        len: usize,
+    };
+
+    fn deinit(ip: *InlineParser) void {
+        ip.pending_inlines.deinit(ip.parent.allocator);
+        ip.completed_inlines.deinit(ip.parent.allocator);
+    }
+
+    /// Parses all of `ip.content`, returning the children of the node
+    /// containing the inline content.
+    fn parse(ip: *InlineParser) Allocator.Error!ExtraIndex {
+        while (ip.pos < ip.content.len) : (ip.pos += 1) {
+            switch (ip.content[ip.pos]) {
+                '\\' => ip.pos += 1,
+                '[' => try ip.pending_inlines.append(ip.parent.allocator, .{
+                    .tag = .link,
+                    .data = .{ .none = {} },
+                    .start = ip.pos,
+                }),
+                '!' => if (ip.pos + 1 < ip.content.len and ip.content[ip.pos + 1] == '[') {
+                    try ip.pending_inlines.append(ip.parent.allocator, .{
+                        .tag = .image,
+                        .data = .{ .none = {} },
+                        .start = ip.pos,
+                    });
+                    ip.pos += 1;
+                },
+                ']' => try ip.parseLink(),
+                '*', '_' => try ip.parseEmphasis(),
+                '`' => try ip.parseCodeSpan(),
+                else => {},
+            }
+        }
+
+        const children = try ip.encodeChildren(0, ip.content.len);
+        // There may be pending inlines after parsing (e.g. unclosed emphasis
+        // runs), but there must not be any completed inlines, since those
+        // should all be part of `children`.
+        assert(ip.completed_inlines.items.len == 0);
+        return children;
+    }
+
+    /// Parses a link, starting at the `]` at the end of the link text. `ip.pos`
+    /// is left at the closing `)` of the link target or at the closing `]` if
+    /// there is none.
+    fn parseLink(ip: *InlineParser) !void {
+        var i = ip.pending_inlines.items.len;
+        while (i > 0) {
+            i -= 1;
+            if (ip.pending_inlines.items[i].tag == .link or
+                ip.pending_inlines.items[i].tag == .image) break;
+        } else return;
+        const opener = ip.pending_inlines.items[i];
+        ip.pending_inlines.shrinkRetainingCapacity(i);
+        const text_start = switch (opener.tag) {
+            .link => opener.start + 1,
+            .image => opener.start + 2,
+            else => unreachable,
+        };
+
+        if (ip.pos + 1 >= ip.content.len or ip.content[ip.pos + 1] != '(') return;
+        const text_end = ip.pos;
+
+        const target_start = text_end + 2;
+        var target_end = target_start;
+        var nesting_level: usize = 1;
+        while (target_end < ip.content.len) : (target_end += 1) {
+            switch (ip.content[target_end]) {
+                '\\' => target_end += 1,
+                '(' => nesting_level += 1,
+                ')' => {
+                    if (nesting_level == 1) break;
+                    nesting_level -= 1;
+                },
+                else => {},
+            }
+        } else return;
+        ip.pos = target_end;
+
+        const children = try ip.encodeChildren(text_start, text_end);
+        const target = try ip.encodeLinkTarget(target_start, target_end);
+
+        const link = try ip.parent.addNode(.{
+            .tag = switch (opener.tag) {
+                .link => .link,
+                .image => .image,
+                else => unreachable,
+            },
+            .data = .{ .link = .{
+                .target = target,
+                .children = children,
+            } },
+        });
+        try ip.completed_inlines.append(ip.parent.allocator, .{
+            .node = link,
+            .start = opener.start,
+            .len = ip.pos - opener.start + 1,
+        });
+    }
+
+    fn encodeLinkTarget(ip: *InlineParser, start: usize, end: usize) !StringIndex {
+        // For efficiency, we can encode directly into string_bytes rather than
+        // creating a temporary string and then encoding it, since this process
+        // is entirely linear.
+        const string_top = ip.parent.string_bytes.items.len;
+        errdefer ip.parent.string_bytes.shrinkRetainingCapacity(string_top);
+
+        var text_iter: TextIterator = .{ .content = ip.content[start..end] };
+        while (text_iter.next()) |content| {
+            switch (content) {
+                .char => |c| try ip.parent.string_bytes.append(ip.parent.allocator, c),
+                .text => |s| try ip.parent.string_bytes.appendSlice(ip.parent.allocator, s),
+                .line_break => try ip.parent.string_bytes.appendSlice(ip.parent.allocator, "\\\n"),
+            }
+        }
+        try ip.parent.string_bytes.append(ip.parent.allocator, 0);
+        return @enumFromInt(string_top);
+    }
+
+    /// Parses emphasis, starting at the beginning of a run of `*` or `_`
+    /// characters. `ip.pos` is left at the last character in the run after
+    /// parsing.
+    fn parseEmphasis(ip: *InlineParser) !void {
+        const char = ip.content[ip.pos];
+        var start = ip.pos;
+        while (ip.pos + 1 < ip.content.len and ip.content[ip.pos + 1] == char) {
+            ip.pos += 1;
+        }
+        var len = ip.pos - start + 1;
+        const underscore = char == '_';
+        const space_before = start == 0 or isWhitespace(ip.content[start - 1]);
+        const space_after = start + len == ip.content.len or isWhitespace(ip.content[start + len]);
+        const punct_before = start == 0 or isPunctuation(ip.content[start - 1]);
+        const punct_after = start + len == ip.content.len or isPunctuation(ip.content[start + len]);
+        // The rules for when emphasis may be closed or opened are stricter for
+        // underscores to avoid inappropriately interpreting snake_case words as
+        // containing emphasis markers.
+        const can_open = if (underscore)
+            !space_after and (space_before or punct_before)
+        else
+            !space_after;
+        const can_close = if (underscore)
+            !space_before and (space_after or punct_after)
+        else
+            !space_before;
+
+        if (can_close and ip.pending_inlines.items.len > 0) {
+            var i = ip.pending_inlines.items.len;
+            while (i > 0 and len > 0) {
+                i -= 1;
+                const opener = &ip.pending_inlines.items[i];
+                if (opener.tag != .emphasis or
+                    opener.data.emphasis.underscore != underscore) continue;
+
+                const close_len = @min(opener.data.emphasis.run_len, len);
+                const opener_end = opener.start + opener.data.emphasis.run_len;
+
+                const emphasis = try ip.encodeEmphasis(opener_end, start, close_len);
+                const emphasis_start = opener_end - close_len;
+                const emphasis_len = start - emphasis_start + close_len;
+                try ip.completed_inlines.append(ip.parent.allocator, .{
+                    .node = emphasis,
+                    .start = emphasis_start,
+                    .len = emphasis_len,
+                });
+
+                // There may still be other openers further down in the
+                // stack to close, or part of this run might serve as an
+                // opener itself.
+                start += close_len;
+                len -= close_len;
+
+                // Remove any pending inlines above this on the stack, since
+                // closing this emphasis will prevent them from being closed.
+                // Additionally, if this opener is completely consumed by
+                // being closed, it can be removed.
+                opener.data.emphasis.run_len -= close_len;
+                if (opener.data.emphasis.run_len == 0) {
+                    ip.pending_inlines.shrinkRetainingCapacity(i);
+                } else {
+                    ip.pending_inlines.shrinkRetainingCapacity(i + 1);
+                }
+            }
+        }
+
+        if (can_open and len > 0) {
+            try ip.pending_inlines.append(ip.parent.allocator, .{
+                .tag = .emphasis,
+                .data = .{ .emphasis = .{
+                    .underscore = underscore,
+                    .run_len = len,
+                } },
+                .start = start,
+            });
+        }
+    }
+
+    /// Encodes emphasis specified by a run of `run_len` emphasis characters,
+    /// with `start..end` being the range of content contained within the
+    /// emphasis.
+    fn encodeEmphasis(ip: *InlineParser, start: usize, end: usize, run_len: usize) !Node.Index {
+        const children = try ip.encodeChildren(start, end);
+        var inner = switch (run_len % 3) {
+            1 => try ip.parent.addNode(.{
+                .tag = .emphasis,
+                .data = .{ .container = .{
+                    .children = children,
+                } },
+            }),
+            2 => try ip.parent.addNode(.{
+                .tag = .strong,
+                .data = .{ .container = .{
+                    .children = children,
+                } },
+            }),
+            0 => strong_emphasis: {
+                const strong = try ip.parent.addNode(.{
+                    .tag = .strong,
+                    .data = .{ .container = .{
+                        .children = children,
+                    } },
+                });
+                break :strong_emphasis try ip.parent.addNode(.{
+                    .tag = .emphasis,
+                    .data = .{ .container = .{
+                        .children = try ip.parent.addExtraChildren(&.{strong}),
+                    } },
+                });
+            },
+            else => unreachable,
+        };
+
+        var run_left = run_len;
+        while (run_left > 3) : (run_left -= 3) {
+            const strong = try ip.parent.addNode(.{
+                .tag = .strong,
+                .data = .{ .container = .{
+                    .children = try ip.parent.addExtraChildren(&.{inner}),
+                } },
+            });
+            inner = try ip.parent.addNode(.{
+                .tag = .emphasis,
+                .data = .{ .container = .{
+                    .children = try ip.parent.addExtraChildren(&.{strong}),
+                } },
+            });
+        }
+
+        return inner;
+    }
+
+    /// Parses a code span, starting at the beginning of the opening backtick
+    /// run. `ip.pos` is left at the last character in the closing run after
+    /// parsing.
+    fn parseCodeSpan(ip: *InlineParser) !void {
+        const opener_start = ip.pos;
+        ip.pos = mem.indexOfNonePos(u8, ip.content, ip.pos, "`") orelse ip.content.len;
+        const opener_len = ip.pos - opener_start;
+
+        const start = ip.pos;
+        const end = while (mem.indexOfScalarPos(u8, ip.content, ip.pos, '`')) |closer_start| {
+            ip.pos = mem.indexOfNonePos(u8, ip.content, closer_start, "`") orelse ip.content.len;
+            const closer_len = ip.pos - closer_start;
+
+            if (closer_len == opener_len) break closer_start;
+        } else unterminated: {
+            ip.pos = ip.content.len;
+            break :unterminated ip.content.len;
+        };
+
+        var content = if (start < ip.content.len)
+            ip.content[start..end]
+        else
+            "";
+        // This single space removal rule allows code spans to be written which
+        // start or end with backticks.
+        if (mem.startsWith(u8, content, " `")) content = content[1..];
+        if (mem.endsWith(u8, content, "` ")) content = content[0 .. content.len - 1];
+
+        const text = try ip.parent.addNode(.{
+            .tag = .code_span,
+            .data = .{ .text = .{
+                .content = try ip.parent.addString(content),
+            } },
+        });
+        try ip.completed_inlines.append(ip.parent.allocator, .{
+            .node = text,
+            .start = opener_start,
+            .len = ip.pos - opener_start,
+        });
+        // Ensure ip.pos is pointing at the last character of the
+        // closer, not after it.
+        ip.pos -= 1;
+    }
+
+    /// Encodes children parsed in the content range `start..end`. The children
+    /// will be text nodes and any completed inlines within the range.
+    fn encodeChildren(ip: *InlineParser, start: usize, end: usize) !ExtraIndex {
+        const scratch_extra_top = ip.parent.scratch_extra.items.len;
+        defer ip.parent.scratch_extra.shrinkRetainingCapacity(scratch_extra_top);
+
+        var child_index = ip.completed_inlines.items.len;
+        while (child_index > 0 and ip.completed_inlines.items[child_index - 1].start >= start) {
+            child_index -= 1;
+        }
+        const start_child_index = child_index;
+
+        var pos = start;
+        while (child_index < ip.completed_inlines.items.len) : (child_index += 1) {
+            const child_inline = ip.completed_inlines.items[child_index];
+            // Completed inlines must be strictly nested within the encodable
+            // content.
+            assert(child_inline.start >= pos and child_inline.start + child_inline.len <= end);
+
+            if (child_inline.start > pos) {
+                try ip.encodeTextNode(pos, child_inline.start);
+            }
+            try ip.parent.addScratchExtraNode(child_inline.node);
+
+            pos = child_inline.start + child_inline.len;
+        }
+        ip.completed_inlines.shrinkRetainingCapacity(start_child_index);
+
+        if (pos < end) {
+            try ip.encodeTextNode(pos, end);
+        }
+
+        const children = ip.parent.scratch_extra.items[scratch_extra_top..];
+        return try ip.parent.addExtraChildren(@ptrCast(children));
+    }
+
+    /// Encodes textual content `ip.content[start..end]` to `scratch_extra`. The
+    /// encoded content may include both `text` and `line_break` nodes.
+    fn encodeTextNode(ip: *InlineParser, start: usize, end: usize) !void {
+        // For efficiency, we can encode directly into string_bytes rather than
+        // creating a temporary string and then encoding it, since this process
+        // is entirely linear.
+        const string_top = ip.parent.string_bytes.items.len;
+        errdefer ip.parent.string_bytes.shrinkRetainingCapacity(string_top);
+
+        var string_start = string_top;
+        var text_iter: TextIterator = .{ .content = ip.content[start..end] };
+        while (text_iter.next()) |content| {
+            switch (content) {
+                .char => |c| try ip.parent.string_bytes.append(ip.parent.allocator, c),
+                .text => |s| try ip.parent.string_bytes.appendSlice(ip.parent.allocator, s),
+                .line_break => {
+                    if (ip.parent.string_bytes.items.len > string_start) {
+                        try ip.parent.string_bytes.append(ip.parent.allocator, 0);
+                        try ip.parent.addScratchExtraNode(try ip.parent.addNode(.{
+                            .tag = .text,
+                            .data = .{ .text = .{
+                                .content = @enumFromInt(string_start),
+                            } },
+                        }));
+                        string_start = ip.parent.string_bytes.items.len;
+                    }
+                    try ip.parent.addScratchExtraNode(try ip.parent.addNode(.{
+                        .tag = .line_break,
+                        .data = .{ .none = {} },
+                    }));
+                },
+            }
+        }
+        if (ip.parent.string_bytes.items.len > string_start) {
+            try ip.parent.string_bytes.append(ip.parent.allocator, 0);
+            try ip.parent.addScratchExtraNode(try ip.parent.addNode(.{
+                .tag = .text,
+                .data = .{ .text = .{
+                    .content = @enumFromInt(string_start),
+                } },
+            }));
+        }
+    }
+
+    /// An iterator over parts of textual content, handling unescaping of
+    /// escaped characters and line breaks.
+    const TextIterator = struct {
+        content: []const u8,
+        pos: usize = 0,
+
+        const Content = union(enum) {
+            char: u8,
+            text: []const u8,
+            line_break,
+        };
+
+        const replacement = "\u{FFFD}";
+
+        fn next(iter: *TextIterator) ?Content {
+            if (iter.pos >= iter.content.len) return null;
+            if (iter.content[iter.pos] == '\\') {
+                iter.pos += 1;
+                if (iter.pos == iter.content.len) {
+                    return .{ .char = '\\' };
+                } else if (iter.content[iter.pos] == '\n') {
+                    iter.pos += 1;
+                    return .line_break;
+                } else if (isPunctuation(iter.content[iter.pos])) {
+                    const c = iter.content[iter.pos];
+                    iter.pos += 1;
+                    return .{ .char = c };
+                } else {
+                    return .{ .char = '\\' };
+                }
+            }
+            return iter.nextCodepoint();
+        }
+
+        fn nextCodepoint(iter: *TextIterator) ?Content {
+            switch (iter.content[iter.pos]) {
+                0 => {
+                    iter.pos += 1;
+                    return .{ .text = replacement };
+                },
+                1...127 => |c| {
+                    iter.pos += 1;
+                    return .{ .char = c };
+                },
+                else => |b| {
+                    const cp_len = std.unicode.utf8ByteSequenceLength(b) catch {
+                        iter.pos += 1;
+                        return .{ .text = replacement };
+                    };
+                    const is_valid = iter.pos + cp_len < iter.content.len and
+                        std.unicode.utf8ValidateSlice(iter.content[iter.pos..][0..cp_len]);
+                    const cp_encoded = if (is_valid)
+                        iter.content[iter.pos..][0..cp_len]
+                    else
+                        replacement;
+                    iter.pos += cp_len;
+                    return .{ .text = cp_encoded };
+                },
+            }
+        }
+    };
+};
+
+fn parseInlines(p: *Parser, content: []const u8) !ExtraIndex {
+    var ip: InlineParser = .{
+        .parent = p,
+        .content = mem.trim(u8, content, " \t\n"),
+    };
+    defer ip.deinit();
+    return try ip.parse();
+}
+
+pub fn extraData(p: Parser, comptime T: type, index: ExtraIndex) ExtraData(T) {
+    const fields = @typeInfo(T).Struct.fields;
+    var i: usize = @intFromEnum(index);
+    var result: T = undefined;
+    inline for (fields) |field| {
+        @field(result, field.name) = switch (field.type) {
+            u32 => p.extra.items[i],
+            else => @compileError("bad field type"),
+        };
+        i += 1;
+    }
+    return .{ .data = result, .end = i };
+}
+
+pub fn extraChildren(p: Parser, index: ExtraIndex) []const Node.Index {
+    const children = p.extraData(Node.Children, index);
+    return @ptrCast(p.extra.items[children.end..][0..children.data.len]);
+}
+
+fn addNode(p: *Parser, node: Node) !Node.Index {
+    const index: Node.Index = @enumFromInt(@as(u32, @intCast(p.nodes.len)));
+    try p.nodes.append(p.allocator, node);
+    return index;
+}
+
+fn addString(p: *Parser, s: []const u8) !StringIndex {
+    if (s.len == 0) return .empty;
+
+    const index: StringIndex = @enumFromInt(@as(u32, @intCast(p.string_bytes.items.len)));
+    try p.string_bytes.ensureUnusedCapacity(p.allocator, s.len + 1);
+    p.string_bytes.appendSliceAssumeCapacity(s);
+    p.string_bytes.appendAssumeCapacity(0);
+    return index;
+}
+
+fn addExtraChildren(p: *Parser, nodes: []const Node.Index) !ExtraIndex {
+    const index: ExtraIndex = @enumFromInt(@as(u32, @intCast(p.extra.items.len)));
+    try p.extra.ensureUnusedCapacity(p.allocator, nodes.len + 1);
+    p.extra.appendAssumeCapacity(@intCast(nodes.len));
+    p.extra.appendSliceAssumeCapacity(@ptrCast(nodes));
+    return index;
+}
+
+fn addScratchExtraNode(p: *Parser, node: Node.Index) !void {
+    try p.scratch_extra.append(p.allocator, @intFromEnum(node));
+}
+
+fn addScratchStringLine(p: *Parser, line: []const u8) !void {
+    try p.scratch_string.ensureUnusedCapacity(p.allocator, line.len + 1);
+    p.scratch_string.appendSliceAssumeCapacity(line);
+    p.scratch_string.appendAssumeCapacity('\n');
+}
+
+fn isBlank(line: []const u8) bool {
+    return mem.indexOfNone(u8, line, " \t") == null;
+}
+
+fn isPunctuation(c: u8) bool {
+    return switch (c) {
+        '!',
+        '"',
+        '#',
+        '$',
+        '%',
+        '&',
+        '\'',
+        '(',
+        ')',
+        '*',
+        '+',
+        ',',
+        '-',
+        '.',
+        '/',
+        ':',
+        ';',
+        '<',
+        '=',
+        '>',
+        '?',
+        '@',
+        '[',
+        '\\',
+        ']',
+        '^',
+        '_',
+        '`',
+        '{',
+        '|',
+        '}',
+        '~',
+        => true,
+        else => false,
+    };
+}

--- a/src/markdown/renderer.zig
+++ b/src/markdown/renderer.zig
@@ -1,0 +1,254 @@
+const std = @import("std");
+const Document = @import("Document.zig");
+const Node = Document.Node;
+
+/// A Markdown document renderer.
+///
+/// Each concrete `Renderer` type has a `renderDefault` function, with the
+/// intention that custom `renderFn` implementations can call `renderDefault`
+/// for node types for which they require no special rendering.
+pub fn Renderer(comptime Writer: type, comptime Context: type) type {
+    return struct {
+        renderFn: *const fn (
+            r: Self,
+            doc: Document,
+            node: Node.Index,
+            writer: Writer,
+        ) Writer.Error!void = renderDefault,
+        context: Context,
+
+        const Self = @This();
+
+        pub fn render(r: Self, doc: Document, writer: Writer) Writer.Error!void {
+            try r.renderFn(r, doc, .root, writer);
+        }
+
+        pub fn renderDefault(
+            r: Self,
+            doc: Document,
+            node: Node.Index,
+            writer: Writer,
+        ) Writer.Error!void {
+            const data = doc.nodes.items(.data)[@intFromEnum(node)];
+            switch (doc.nodes.items(.tag)[@intFromEnum(node)]) {
+                .root => {
+                    for (doc.extraChildren(data.container.children)) |child| {
+                        try r.renderFn(r, doc, child, writer);
+                    }
+                },
+                .list => {
+                    if (data.list.start.asNumber()) |start| {
+                        if (start == 1) {
+                            try writer.writeAll("<ol>\n");
+                        } else {
+                            try writer.print("<ol start=\"{}\">\n", .{start});
+                        }
+                    } else {
+                        try writer.writeAll("<ul>\n");
+                    }
+                    for (doc.extraChildren(data.list.children)) |child| {
+                        try r.renderFn(r, doc, child, writer);
+                    }
+                    if (data.list.start.asNumber() != null) {
+                        try writer.writeAll("</ol>\n");
+                    } else {
+                        try writer.writeAll("</ul>\n");
+                    }
+                },
+                .list_item => {
+                    try writer.writeAll("<li>");
+                    for (doc.extraChildren(data.list_item.children)) |child| {
+                        if (data.list_item.tight and doc.nodes.items(.tag)[@intFromEnum(child)] == .paragraph) {
+                            const para_data = doc.nodes.items(.data)[@intFromEnum(child)];
+                            for (doc.extraChildren(para_data.container.children)) |para_child| {
+                                try r.renderFn(r, doc, para_child, writer);
+                            }
+                        } else {
+                            try r.renderFn(r, doc, child, writer);
+                        }
+                    }
+                    try writer.writeAll("</li>\n");
+                },
+                .table => {
+                    try writer.writeAll("<table>\n");
+                    for (doc.extraChildren(data.container.children)) |child| {
+                        try r.renderFn(r, doc, child, writer);
+                    }
+                    try writer.writeAll("</table>\n");
+                },
+                .table_row => {
+                    try writer.writeAll("<tr>\n");
+                    for (doc.extraChildren(data.container.children)) |child| {
+                        try r.renderFn(r, doc, child, writer);
+                    }
+                    try writer.writeAll("</tr>\n");
+                },
+                .table_cell => {
+                    if (data.table_cell.info.header) {
+                        try writer.writeAll("<th");
+                    } else {
+                        try writer.writeAll("<td");
+                    }
+                    switch (data.table_cell.info.alignment) {
+                        .unset => try writer.writeAll(">"),
+                        else => |a| try writer.print(" style=\"text-align: {s}\">", .{@tagName(a)}),
+                    }
+
+                    for (doc.extraChildren(data.table_cell.children)) |child| {
+                        try r.renderFn(r, doc, child, writer);
+                    }
+
+                    if (data.table_cell.info.header) {
+                        try writer.writeAll("</th>\n");
+                    } else {
+                        try writer.writeAll("</td>\n");
+                    }
+                },
+                .heading => {
+                    try writer.print("<h{}>", .{data.heading.level});
+                    for (doc.extraChildren(data.heading.children)) |child| {
+                        try r.renderFn(r, doc, child, writer);
+                    }
+                    try writer.print("</h{}>\n", .{data.heading.level});
+                },
+                .code_block => {
+                    const tag = doc.string(data.code_block.tag);
+                    const content = doc.string(data.code_block.content);
+                    if (tag.len > 0) {
+                        try writer.print("<pre><code class=\"{}\">{}</code></pre>\n", .{ fmtHtml(tag), fmtHtml(content) });
+                    } else {
+                        try writer.print("<pre><code>{}</code></pre>\n", .{fmtHtml(content)});
+                    }
+                },
+                .blockquote => {
+                    try writer.writeAll("<blockquote>\n");
+                    for (doc.extraChildren(data.container.children)) |child| {
+                        try r.renderFn(r, doc, child, writer);
+                    }
+                    try writer.writeAll("</blockquote>\n");
+                },
+                .paragraph => {
+                    try writer.writeAll("<p>");
+                    for (doc.extraChildren(data.container.children)) |child| {
+                        try r.renderFn(r, doc, child, writer);
+                    }
+                    try writer.writeAll("</p>\n");
+                },
+                .thematic_break => {
+                    try writer.writeAll("<hr />\n");
+                },
+                .link => {
+                    const target = doc.string(data.link.target);
+                    try writer.print("<a href=\"{}\">", .{fmtHtml(target)});
+                    for (doc.extraChildren(data.link.children)) |child| {
+                        try r.renderFn(r, doc, child, writer);
+                    }
+                    try writer.writeAll("</a>");
+                },
+                .image => {
+                    const target = doc.string(data.link.target);
+                    try writer.print("<img src=\"{}\" alt=\"", .{fmtHtml(target)});
+                    for (doc.extraChildren(data.link.children)) |child| {
+                        try renderInlineNodeText(doc, child, writer);
+                    }
+                    try writer.writeAll("\" />");
+                },
+                .strong => {
+                    try writer.writeAll("<strong>");
+                    for (doc.extraChildren(data.container.children)) |child| {
+                        try r.renderFn(r, doc, child, writer);
+                    }
+                    try writer.writeAll("</strong>");
+                },
+                .emphasis => {
+                    try writer.writeAll("<em>");
+                    for (doc.extraChildren(data.container.children)) |child| {
+                        try r.renderFn(r, doc, child, writer);
+                    }
+                    try writer.writeAll("</em>");
+                },
+                .code_span => {
+                    const content = doc.string(data.text.content);
+                    try writer.print("<code>{}</code>", .{fmtHtml(content)});
+                },
+                .text => {
+                    const content = doc.string(data.text.content);
+                    try writer.print("{}", .{fmtHtml(content)});
+                },
+                .line_break => {
+                    try writer.writeAll("<br />\n");
+                },
+            }
+        }
+    };
+}
+
+/// Renders an inline node as plain text. Asserts that the node is an inline and
+/// has no non-inline children.
+pub fn renderInlineNodeText(
+    doc: Document,
+    node: Node.Index,
+    writer: anytype,
+) @TypeOf(writer).Error!void {
+    const data = doc.nodes.items(.data)[@intFromEnum(node)];
+    switch (doc.nodes.items(.tag)[@intFromEnum(node)]) {
+        .root,
+        .list,
+        .list_item,
+        .table,
+        .table_row,
+        .table_cell,
+        .heading,
+        .code_block,
+        .blockquote,
+        .paragraph,
+        .thematic_break,
+        => unreachable, // Blocks
+
+        .link, .image => {
+            for (doc.extraChildren(data.link.children)) |child| {
+                try renderInlineNodeText(doc, child, writer);
+            }
+        },
+        .strong => {
+            for (doc.extraChildren(data.container.children)) |child| {
+                try renderInlineNodeText(doc, child, writer);
+            }
+        },
+        .emphasis => {
+            for (doc.extraChildren(data.container.children)) |child| {
+                try renderInlineNodeText(doc, child, writer);
+            }
+        },
+        .code_span, .text => {
+            const content = doc.string(data.text.content);
+            try writer.print("{}", .{fmtHtml(content)});
+        },
+        .line_break => {
+            try writer.writeAll("\n");
+        },
+    }
+}
+
+pub fn fmtHtml(bytes: []const u8) std.fmt.Formatter(formatHtml) {
+    return .{ .data = bytes };
+}
+
+fn formatHtml(
+    bytes: []const u8,
+    comptime fmt: []const u8,
+    options: std.fmt.FormatOptions,
+    writer: anytype,
+) !void {
+    _ = fmt;
+    _ = options;
+    for (bytes) |b| {
+        switch (b) {
+            '<' => try writer.writeAll("&lt;"),
+            '>' => try writer.writeAll("&gt;"),
+            '&' => try writer.writeAll("&amp;"),
+            '"' => try writer.writeAll("&quot;"),
+            else => try writer.writeByte(b),
+        }
+    }
+}


### PR DESCRIPTION
The variant of Markdown parsed by this implementation is described in the documentation of `markdown.zig`, which also contains several test cases for the parser and default renderer.

---

Some points of interest when testing this out:

- `#std.fmt.format` - complex doc comment involving nested lists
- `#std.math.atan2.atan2` and `#std.math.hypot.hypot` - tables (see https://github.com/ziglang/zig/pull/18623)
- `#std.zig.Zir` - rendering of field doc comments
- `#std.ascii` - link rendering (the bare https:// link isn't rendered as a link, currently, this is something that could be implemented if desired)
- `#std.log` - big code block that should be syntax highlighted (see TODOs)
- `#std.fmt` - contains several examples of "short" documentation rendering (where the full documentation is not rendered for each function to save space)

---

**TODO:**

- [ ] Reconsider the `Renderer` API, it seems clunky and there must be a better way to do it
- [ ] Hook up decl linking and syntax highlighting at the TODO comment in `main.zig`