### PR TITLE
use rdynamic to expose all exported functions

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -29,34 +29,8 @@ pub fn build(b: *std.Build) void {
         }),
         .optimize = optimize,
     });
-    // It would be nice if Zig could just use the exact list of functions that
-    // are exported in `wasm`.
-    wasm.root_module.export_symbol_names = &.{
-        "alloc",
-        "categorize_decl",
-        "decl_category_name",
-        "decl_docs_html",
-        "decl_doctest_html",
-        "decl_field_html",
-        "decl_fields",
-        "decl_file_path",
-        "decl_fn_proto_html",
-        "decl_fqn",
-        "decl_name",
-        "decl_parent",
-        "decl_source_html",
-        "decl_type_html",
-        "find_decl",
-        "find_file_root",
-        "find_package_root",
-        "get_aliasee",
-        "namespace_members",
-        "package_name",
-        "query_begin",
-        "query_exec",
-        "set_input_string",
-        "unpack",
-    };
+    // expose exported functions to wasm
+    wasm.rdynamic = true;
     wasm.entry = .disabled;
 
     b.getInstallStep().dependOn(&b.addInstallFile(wasm.getEmittedBin(), "main.wasm").step);


### PR DESCRIPTION
Hi, I've been using `rdynamic = true` on my Zig/Wasm projects to expose all exported functions.